### PR TITLE
How about supporting http.Handler instead of just only http.HandlerFunc

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -317,9 +317,9 @@ func init() {
 
 	calcMem("goblin", func() {
 		router := NewRouter()
-		handler := func(w http.ResponseWriter, _ *http.Request) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(204)
-		}
+		})
 		for _, route := range githubAPI {
 			router.Handle(route.method, route.path, handler)
 		}

--- a/router.go
+++ b/router.go
@@ -19,37 +19,37 @@ func NewRouter() *Router {
 }
 
 // GET set a route for GET method.
-func (r *Router) GET(path string, handler http.HandlerFunc) {
+func (r *Router) GET(path string, handler http.Handler) {
 	r.Handle(http.MethodGet, path, handler)
 }
 
 // POST set a route for POST method.
-func (r *Router) POST(path string, handler http.HandlerFunc) {
+func (r *Router) POST(path string, handler http.Handler) {
 	r.Handle(http.MethodPost, path, handler)
 }
 
 // PUT set a route for PUT method.
-func (r *Router) PUT(path string, handler http.HandlerFunc) {
+func (r *Router) PUT(path string, handler http.Handler) {
 	r.Handle(http.MethodPut, path, handler)
 }
 
 // PATCH set a route for PATCH method.
-func (r *Router) PATCH(path string, handler http.HandlerFunc) {
+func (r *Router) PATCH(path string, handler http.Handler) {
 	r.Handle(http.MethodPatch, path, handler)
 }
 
 // DELETE set a route for DELETE method.
-func (r *Router) DELETE(path string, handler http.HandlerFunc) {
+func (r *Router) DELETE(path string, handler http.Handler) {
 	r.Handle(http.MethodDelete, path, handler)
 }
 
 // OPTION set a route for OPTION method.
-func (r *Router) OPTION(path string, handler http.HandlerFunc) {
+func (r *Router) OPTION(path string, handler http.Handler) {
 	r.Handle(http.MethodOptions, path, handler)
 }
 
 // Handle handle a route.
-func (r *Router) Handle(method string, path string, handler http.HandlerFunc) {
+func (r *Router) Handle(method string, path string, handler http.Handler) {
 	r.tree.Insert(method, path, handler)
 }
 
@@ -78,7 +78,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		req = req.WithContext(ctx)
 	}
 
-	result.handler(w, req)
+	result.handler.ServeHTTP(w, req)
 }
 
 // GetParam get parameters from request.

--- a/trie.go
+++ b/trie.go
@@ -15,7 +15,7 @@ type Tree struct {
 // Node is a node of tree.
 type Node struct {
 	label    string
-	handler  http.HandlerFunc
+	handler  http.Handler
 	children map[string]*Node
 }
 
@@ -30,7 +30,7 @@ type Params []*Param
 
 // Result is a search result.
 type Result struct {
-	handler http.HandlerFunc
+	handler http.Handler
 	params  Params
 }
 
@@ -81,7 +81,7 @@ func NewTree() *Tree {
 }
 
 // Insert insert a route definition to tree.
-func (t *Tree) Insert(method string, path string, handler http.HandlerFunc) error {
+func (t *Tree) Insert(method string, path string, handler http.Handler) error {
 	curNode := t.method[method]
 
 	if path == pathDelimiter {

--- a/trie.go
+++ b/trie.go
@@ -46,32 +46,32 @@ const (
 func NewTree() *Tree {
 	return &Tree{
 		method: map[string]*Node{
-			http.MethodGet: &Node{
+			http.MethodGet: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodPost: &Node{
+			http.MethodPost: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodPut: &Node{
+			http.MethodPut: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodPatch: &Node{
+			http.MethodPatch: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodDelete: &Node{
+			http.MethodDelete: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodOptions: &Node{
+			http.MethodOptions: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),

--- a/trie_test.go
+++ b/trie_test.go
@@ -10,32 +10,32 @@ func TestNewTree(t *testing.T) {
 	actual := NewTree()
 	expected := &Tree{
 		method: map[string]*Node{
-			http.MethodGet: &Node{
+			http.MethodGet: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodPost: &Node{
+			http.MethodPost: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodPut: &Node{
+			http.MethodPut: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodPatch: &Node{
+			http.MethodPatch: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodDelete: &Node{
+			http.MethodDelete: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),
 			},
-			http.MethodOptions: &Node{
+			http.MethodOptions: {
 				label:    "",
 				handler:  nil,
 				children: make(map[string]*Node),

--- a/trie_test.go
+++ b/trie_test.go
@@ -657,7 +657,7 @@ func TestNegativeSearchRegexp(t *testing.T) {
 	for _, c := range cases {
 		actual, err := tree.Search(c.item.method, c.item.path)
 		if err != nil {
-			if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
+			if !(actual.handler == nil && c.expected.handler == nil) && reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
 				t.Errorf("error:%v actual handler:%v actual params:%v expected:%v", err, actual.handler, actual.params, c.expected)
 			}
 
@@ -870,7 +870,7 @@ func TestPositiveAndNegativeSearchRandom(t *testing.T) {
 	for _, c := range cases {
 		actual, err := tree.Search(c.item.method, c.item.path)
 		if err != nil {
-			if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
+			if !(actual.handler == nil && c.expected.handler == nil) && reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
 				t.Errorf("error:%v actual handler:%v actual params:%v expected:%v", err, actual.handler, actual.params, c.expected)
 			}
 
@@ -885,7 +885,7 @@ func TestPositiveAndNegativeSearchRandom(t *testing.T) {
 			}
 		}
 
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
+		if !(actual.handler == nil && c.expected.handler == nil) && reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
 			t.Errorf("actual handler:%v actual params:%v expected:%v", actual.handler, actual.params, c.expected)
 		}
 


### PR DESCRIPTION
# Overview

router acceps `http.Handler`. 

# Changes

# Impact range

This should not be a problem since http.HandlerFunc already implements http.Handler.

# Operational Requirements

# Related Issue

# Supplement
