### PR TITLE
Fix typo in comments and error messages, code block language in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Run a total of 203 routes of GithubAPI.
 - [go-chi/chi](https://github.com/go-chi/chi)
 
 ## How to run
-```go
+```sh
 cd benchmark
 go test -bench . -benchmem
 ```

--- a/trie.go
+++ b/trie.go
@@ -138,7 +138,7 @@ func (rc *regCache) Get(ptn string) (*regexp.Regexp, error) {
 
 var regC = &regCache{}
 
-// Search searchs a path from a tree.
+// Search searches a path from a tree.
 func (t *Tree) Search(method string, path string) (*Result, error) {
 	var params Params
 
@@ -162,7 +162,7 @@ func (t *Tree) Search(method string, path string) (*Result, error) {
 			// 3 /foo/:id[^\w+$]
 			// priority is 1, 2, 3
 			if len(curNode.children) == 0 {
-				return &Result{}, errors.New("handler is not regsitered")
+				return &Result{}, errors.New("handler is not registered")
 			}
 
 			count := 0
@@ -193,7 +193,7 @@ func (t *Tree) Search(method string, path string) (*Result, error) {
 
 				// If no match is found until the last loop.
 				if count == len(curNode.children) {
-					return &Result{}, errors.New("handler is not regsitered")
+					return &Result{}, errors.New("handler is not registered")
 				}
 			}
 		}


### PR DESCRIPTION
# Overview

- Fix typo in comments and error messages
- Fix code block language in README

# Changes

## Comments

- `searchs` -> `searches`

## Error messages

- `regsitered` -> `registered`

## README

- `go` -> `sh`

# Impact range

- Some error handlings using error message string directly, if any.

# Operational Requirements

# Related Issue

# Supplement
