### PR TITLE
[update] implement methods method

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -34,35 +34,35 @@ func third(next http.Handler) http.Handler {
 func main() {
 	r := goblin.NewRouter()
 
-	r.GET(`/middleware`).Use(first).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Use(first).Handler(`/middleware`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "middleware\n")
 	}))
-	r.GET(`/middlewares`).Use(second, third).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Use(second, third).Handler(`/middlewares`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "middlewares\n")
 	}))
-	r.GET(`/`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/")
 	}))
-	r.GET(`/foo`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/foo")
 	}))
-	r.GET(`/foo/bar`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/bar`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/foo/bar")
 	}))
-	r.GET(`/foo/bar/:id`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/bar/:id`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		fmt.Fprintf(w, "/foo/bar/%v", id)
 	}))
-	r.GET(`/foo/bar/:id/:name`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/bar:id/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		name := goblin.GetParam(r.Context(), "name")
 		fmt.Fprintf(w, "/foo/bar/%v/%v", id, name)
 	}))
-	r.GET(`/foo/:id[^\d+$]`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		fmt.Fprintf(w, "/foo/%v", id)
 	}))
-	r.GET(`/foo/:id[^\d+$]/:name`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		name := goblin.GetParam(r.Context(), "name")
 		fmt.Fprintf(w, "/foo/%v/%v", id, name)

--- a/router.go
+++ b/router.go
@@ -13,7 +13,7 @@ type Router struct {
 
 // route represents the route which has data for a routing.
 type route struct {
-	method      string
+	methods     []string
 	path        string
 	handler     http.Handler
 	middlewares middlewares
@@ -35,57 +35,21 @@ func (r *Router) Use(mws ...middleware) *Router {
 	return r
 }
 
-// GET sets a route for GET method.
-func (r *Router) GET(path string) *Router {
-	tmpRoute.method = http.MethodGet
-	tmpRoute.path = path
-	return r
-}
-
-// POST sets a route for POST method.
-func (r *Router) POST(path string) *Router {
-	tmpRoute.method = http.MethodPost
-	tmpRoute.path = path
-	return r
-}
-
-// PUT sets a route for PUT method.
-func (r *Router) PUT(path string) *Router {
-	tmpRoute.method = http.MethodPut
-	tmpRoute.path = path
-	return r
-}
-
-// PATCH sets a route for PATCH method.
-func (r *Router) PATCH(path string) *Router {
-	tmpRoute.method = http.MethodPatch
-	tmpRoute.path = path
-	return r
-}
-
-// DELETE sets a route for DELETE method.
-func (r *Router) DELETE(path string) *Router {
-	tmpRoute.method = http.MethodDelete
-	tmpRoute.path = path
-	return r
-}
-
-// OPTIONS sets a route for OPTIONS method.
-func (r *Router) OPTIONS(path string) *Router {
-	tmpRoute.method = http.MethodOptions
-	tmpRoute.path = path
+func (r *Router) Methods(methods ...string) *Router {
+	tmpRoute.methods = append(tmpRoute.methods, methods...)
 	return r
 }
 
 // Handler sets a handler.
-func (r *Router) Handler(handler http.Handler) {
+func (r *Router) Handler(path string, handler http.Handler) {
 	tmpRoute.handler = handler
+	tmpRoute.path = path
 	r.Handle()
 }
 
 // Handle handles a route.
 func (r *Router) Handle() {
-	r.tree.Insert(tmpRoute.method, tmpRoute.path, tmpRoute.handler, tmpRoute.middlewares)
+	r.tree.Insert(tmpRoute.methods, tmpRoute.path, tmpRoute.handler, tmpRoute.middlewares)
 	tmpRoute = &route{}
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -23,70 +23,70 @@ func TestNewRouter(t *testing.T) {
 func TestRouter(t *testing.T) {
 	r := NewRouter()
 
-	r.GET(`/`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/")
 	}))
-	r.GET(`/middleware`).Use(first).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Use(first).Handler(`/middleware`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/middleware\n")
 	}))
-	r.GET(`/middlewares`).Use(first, second, third).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Use(first, second, third).Handler(`/middlewares`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/middlewares\n")
 	}))
-	r.GET(`/foo`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/foo")
 	}))
-	r.GET(`/foo/bar`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/bar`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/foo/bar")
 	}))
-	r.GET(`/foo/bar/:id`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/bar/:id`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		fmt.Fprintf(w, "/foo/bar/%v", id)
 	}))
-	r.GET(`/foo/bar/:id/:name`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/bar/:id/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		name := GetParam(r.Context(), "name")
 		fmt.Fprintf(w, "/foo/bar/%v/%v", id, name)
 	}))
-	r.GET(`/foo/:id[^\d+$]`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		fmt.Fprintf(w, "/foo/%v", id)
 	}))
-	r.GET(`/foo/:id[^\d+$]/:name`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		name := GetParam(r.Context(), "name")
 		fmt.Fprintf(w, "/foo/%v/%v", id, name)
 	}))
-	r.POST(`/`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodPost).Handler(`/`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/")
 	}))
-	r.POST(`/foo`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodPost).Handler(`/foo`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/foo")
 	}))
-	r.POST(`/foo/bar`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodPost).Handler(`/foo/bar`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/foo/bar")
 	}))
-	r.POST(`/foo/bar/:id`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodPost).Handler(`/foo/bar/:id`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		fmt.Fprintf(w, "/foo/bar/%v", id)
 	}))
-	r.POST(`/foo/bar/:id/:name`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodPost).Handler(`/foo/bar/:id/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		name := GetParam(r.Context(), "name")
 		fmt.Fprintf(w, "/foo/bar/%v/%v", id, name)
 	}))
-	r.POST(`/foo/:id[^\d+$]`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodPost).Handler(`/foo/:id[^\d+$]`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		fmt.Fprintf(w, "/foo/%v", id)
 	}))
-	r.POST(`/foo/:id[^\d+$]/:name`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodPost).Handler(`/foo/:id[^\d+$]/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		name := GetParam(r.Context(), "name")
 		fmt.Fprintf(w, "/foo/%v/%v", id, name)
 	}))
-	r.OPTIONS(`/options`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodOptions).Handler(`/options`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "/options")
 	}))
-	r.OPTIONS(`:id`).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodOptions).Handler(`/:id`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := GetParam(r.Context(), "id")
 		fmt.Fprintf(w, "/%v", id)
 	}))

--- a/trie_test.go
+++ b/trie_test.go
@@ -84,7 +84,7 @@ func TestInsert(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if err := tree.Insert(c.method, c.path, c.handler, c.middlewares); err != nil {
+		if err := tree.Insert([]string{c.method}, c.path, c.handler, c.middlewares); err != nil {
 			t.Errorf("err: %v\n", err)
 		}
 	}
@@ -110,16 +110,16 @@ func TestSearchAllMethod(t *testing.T) {
 	rootDeleteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooDeleteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodGet, "/", rootGetHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo", fooGetHandler, []middleware{first})
-	tree.Insert(http.MethodPost, "/", rootPostHandler, []middleware{first})
-	tree.Insert(http.MethodPost, "/foo", fooPostHandler, []middleware{first})
-	tree.Insert(http.MethodPut, "/", rootPutHandler, []middleware{first})
-	tree.Insert(http.MethodPut, "/foo", fooPutHandler, []middleware{first})
-	tree.Insert(http.MethodPatch, `/`, rootPatchHandler, []middleware{first})
-	tree.Insert(http.MethodPatch, `/foo`, fooPatchHandler, []middleware{first})
-	tree.Insert(http.MethodDelete, `/`, rootDeleteHandler, []middleware{first})
-	tree.Insert(http.MethodDelete, `/foo`, fooDeleteHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/", rootGetHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo", fooGetHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPost}, "/", rootPostHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPost}, "/foo", fooPostHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPut}, "/", rootPutHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPut}, "/foo", fooPutHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPatch}, `/`, rootPatchHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPatch}, `/foo`, fooPatchHandler, []middleware{first})
+	tree.Insert([]string{http.MethodDelete}, `/`, rootDeleteHandler, []middleware{first})
+	tree.Insert([]string{http.MethodDelete}, `/foo`, fooDeleteHandler, []middleware{first})
 
 	cases := []struct {
 		item     *Item
@@ -275,8 +275,8 @@ func TestSearchWithoutRoot(t *testing.T) {
 	fooHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	barHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodGet, "/foo", fooHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/bar", barHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/bar", barHandler, []middleware{first})
 
 	cases := []struct {
 		item     *Item
@@ -346,10 +346,10 @@ func TestSearchTrailingSlash(t *testing.T) {
 	barHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooBarHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodGet, "/", rootHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo/", fooHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/bar/", barHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo/bar/", fooBarHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo/", fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/bar/", barHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo/bar/", fooBarHandler, []middleware{first})
 
 	cases := []struct {
 		item     *Item
@@ -474,10 +474,10 @@ func TestSearchStaticPath(t *testing.T) {
 	barHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooBarHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodGet, "/", rootHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo", fooHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/bar", barHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo/bar", fooBarHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/bar", barHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo/bar", fooBarHandler, []middleware{first})
 
 	cases := []struct {
 		item     *Item
@@ -568,9 +568,9 @@ func TestSearchPathWithParams(t *testing.T) {
 	fooIDNameHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooIDNameDateHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodGet, `/foo/:id`, fooIDHandler, []middleware{first})
-	tree.Insert(http.MethodGet, `/foo/:id/:name`, fooIDNameHandler, []middleware{first})
-	tree.Insert(http.MethodGet, `/foo/:id/:name/:date`, fooIDNameDateHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/:id`, fooIDHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/:id/:name`, fooIDNameHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/:id/:name/:date`, fooIDNameDateHandler, []middleware{first})
 
 	cases := []struct {
 		item     *Item
@@ -680,12 +680,12 @@ func TestSearchPriority(t *testing.T) {
 	IDHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	IDPriorityHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodGet, "/", rootHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/", rootPriorityHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo", fooHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo", fooPriorityHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/:id", IDHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/:id", IDPriorityHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/", rootPriorityHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo", fooPriorityHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/:id", IDHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/:id", IDPriorityHandler, []middleware{first})
 
 	cases := []struct {
 		item     *Item
@@ -776,14 +776,14 @@ func TestSearchRegexp(t *testing.T) {
 	fooBarIDHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooBarIDNameHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodGet, "/", rootHandler, []middleware{first})
-	tree.Insert(http.MethodOptions, `/:*[(.+)]`, rootWildCardHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo", fooHandler, []middleware{first})
-	tree.Insert(http.MethodGet, `/foo/:id[^\d+$]`, fooIDHandler, []middleware{first})
-	tree.Insert(http.MethodGet, `/foo/:id[^\d+$]/:name[^\D+$]`, fooIDNameHandler, []middleware{first})
-	tree.Insert(http.MethodGet, "/foo/bar", fooBarHandler, []middleware{first})
-	tree.Insert(http.MethodGet, `/foo/bar/:id`, fooBarIDHandler, []middleware{first})
-	tree.Insert(http.MethodGet, `/foo/bar/:id/:name`, fooBarIDNameHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodOptions}, `/:*[(.+)]`, rootWildCardHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/:id[^\d+$]`, fooIDHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/:id[^\d+$]/:name[^\D+$]`, fooIDNameHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, "/foo/bar", fooBarHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/bar/:id`, fooBarIDHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/bar/:id/:name`, fooBarIDNameHandler, []middleware{first})
 
 	cases := []struct {
 		hasError bool
@@ -1088,8 +1088,8 @@ func TestSearchWildCardRegexp(t *testing.T) {
 	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	rootWildCardHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert(http.MethodOptions, `/`, rootHandler, []middleware{first})
-	tree.Insert(http.MethodOptions, `/:*[(.+)]`, rootWildCardHandler, []middleware{first})
+	tree.Insert([]string{http.MethodOptions}, `/`, rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodOptions}, `/:*[(.+)]`, rootWildCardHandler, []middleware{first})
 
 	cases := []struct {
 		item     *Item


### PR DESCRIPTION
# Overview
Implement a new methods for routing definition.

# Changes
Abolished methods such as `router.GET` and `router.POST`, and added new `Methods` that can register multiple methods.

# Impact range

# Operational Requirements

# Related Issue
https://github.com/bmf-san/goblin/issues/38

# Supplement
