### PR TITLE
Fix bugs and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ r.Methods(http.MethodGet).Handler(`/`, http.HandlerFunc(func(w http.ResponseWrit
 })
 
 r.Methods(http.MethodGet, http.MethodPost).Handler(`/methods`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    fmt.Fprintf(w, "/methods")
+    if r.Method == http.MethodGet {
+        fmt.Fprintf(w, "GET")
+    }
+    if r.Method == http.MethodPost {
+        fmt.Fprintf(w, "POST")
+    }
 })
 
 http.ListenAndServe(":9999", r)

--- a/_examples/main.go
+++ b/_examples/main.go
@@ -35,36 +35,49 @@ func main() {
 	r := goblin.NewRouter()
 
 	r.Methods(http.MethodGet).Use(first).Handler(`/middleware`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "/middleware\n")
 		fmt.Fprintf(w, "middleware\n")
 	}))
 	r.Methods(http.MethodGet).Use(second, third).Handler(`/middlewares`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "/middlewares\n")
 		fmt.Fprintf(w, "middlewares\n")
 	}))
 	r.Methods(http.MethodGet).Handler(`/`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "/\n")
 		fmt.Fprintf(w, "/")
 	}))
 	r.Methods(http.MethodGet).Handler(`/foo`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "/foo\n")
 		fmt.Fprintf(w, "/foo")
 	}))
+	r.Methods(http.MethodGet).Handler(`/bar`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "/bar\n")
+		fmt.Fprintf(w, "/bar")
+	}))
 	r.Methods(http.MethodGet).Handler(`/foo/bar`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "/foo/bar\n")
 		fmt.Fprintf(w, "/foo/bar")
 	}))
 	r.Methods(http.MethodGet).Handler(`/foo/bar/:id`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
+		fmt.Fprint(w, "/foo/bar/:id\n")
 		fmt.Fprintf(w, "/foo/bar/%v", id)
 	}))
-	r.Methods(http.MethodGet).Handler(`/foo/bar:id/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods(http.MethodGet).Handler(`/foo/bar/:id/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		name := goblin.GetParam(r.Context(), "name")
+		fmt.Fprint(w, "/foo/bar/:id/:name\n")
 		fmt.Fprintf(w, "/foo/bar/%v/%v", id, name)
 	}))
 	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
+		fmt.Fprint(w, "/foo/:id[^\\d+$]\n")
 		fmt.Fprintf(w, "/foo/%v", id)
 	}))
 	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		name := goblin.GetParam(r.Context(), "name")
+		fmt.Fprint(w, "/foo/:id[^\\d+$]/:name\n")
 		fmt.Fprintf(w, "/foo/%v/%v", id, name)
 	}))
 

--- a/context.go
+++ b/context.go
@@ -11,7 +11,7 @@ const (
 
 // GetParam gets parameters from request.
 func GetParam(ctx context.Context, name string) string {
-	params, _ := ctx.Value(ParamsKey).(Params)
+	params, _ := ctx.Value(ParamsKey).(params)
 
 	for i := range params {
 		if params[i].key == name {

--- a/context_test.go
+++ b/context_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 func TestGetParam(t *testing.T) {
-	params := &Params{
-		&Param{
+	params := &params{
+		&param{
 			key:   "id",
 			value: "123",
 		},
-		&Param{
+		&param{
 			key:   "name",
 			value: "john",
 		},

--- a/router_test.go
+++ b/router_test.go
@@ -224,3 +224,26 @@ func TestRouter(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleErr(t *testing.T) {
+	cases := []struct {
+		actual   int
+		expected int
+	}{
+		{
+			actual:   handleErr(ErrMethodNotAllowed),
+			expected: http.StatusMethodNotAllowed,
+		},
+		{
+			actual:   handleErr(ErrNotFound),
+			expected: http.StatusNotFound,
+		},
+	}
+
+	for _, c := range cases {
+		if c.actual != c.expected {
+			t.Errorf("actual: %v expected: %v\n", c.actual, c.expected)
+		}
+	}
+
+}

--- a/trie_test.go
+++ b/trie_test.go
@@ -3,18 +3,25 @@ package goblin
 import (
 	"net/http"
 	"reflect"
-	"strings"
 	"testing"
 )
 
+func TestNewResult(t *testing.T) {
+	actual := newResult()
+	expected := &result{}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("actual: %v expected: %v\n", actual, expected)
+	}
+}
+
 func TestNewTree(t *testing.T) {
 	actual := NewTree()
-	expected := &Tree{
-		node: &Node{
-			label:       pathRoot,
-			actions:     make(map[string]http.Handler),
-			middlewares: nil,
-			children:    make(map[string]*Node),
+	expected := &tree{
+		node: &node{
+			label:    pathRoot,
+			actions:  make(map[string]*action),
+			children: make(map[string]*node),
 		},
 	}
 
@@ -90,10 +97,327 @@ func TestInsert(t *testing.T) {
 	}
 }
 
-// Item is a set of routing definition.
-type Item struct {
+// item is a set of routing definition.
+type item struct {
 	method string
 	path   string
+}
+
+// caseOnlySuccess is a struct for testOnlySuccess.
+type caseOnlySuccess struct {
+	item     *item
+	expected *result
+}
+
+// caseWithFailure is a struct for testWithFailure.
+type caseWithFailure struct {
+	hasError bool
+	item     *item
+	expected *result
+}
+
+// insertItem is a struct for insert method.
+type insertItem struct {
+	methods     []string
+	path        string
+	handler     http.Handler
+	middlewares []middleware
+}
+
+// searchItem is a struct for search method.
+type searchItem struct {
+	method string
+	path   string
+}
+
+func TestSearchFailure(t *testing.T) {
+	fooHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	cases := []struct {
+		insertItems []*insertItem
+		searchItem  *searchItem
+		expected    error
+	}{
+		{
+			// no matching path was found.
+			insertItems: []*insertItem{
+				&insertItem{
+					methods:     []string{http.MethodGet},
+					path:        `/foo`,
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+			},
+			searchItem: &searchItem{
+				method: http.MethodGet,
+				path:   "/foo/bar",
+			},
+			expected: ErrNotFound,
+		},
+		{
+			// no matching param was found.
+			insertItems: []*insertItem{
+				&insertItem{
+					methods:     []string{http.MethodGet},
+					path:        `/foo/:id[^\d+$]`,
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+			},
+			searchItem: &searchItem{
+				method: http.MethodGet,
+				path:   "/foo/name",
+			},
+			expected: ErrNotFound,
+		},
+		{
+			// no matching param was found.
+			insertItems: []*insertItem{
+				&insertItem{
+					methods:     []string{http.MethodGet},
+					path:        `/foo`,
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+			},
+			searchItem: &searchItem{
+				method: http.MethodGet,
+				path:   "/bar",
+			},
+			expected: ErrNotFound,
+		},
+		{
+			// no matching handler and middlewares was found.
+			insertItems: []*insertItem{
+				&insertItem{
+					methods:     []string{http.MethodGet},
+					path:        `/foo`,
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+			},
+			searchItem: &searchItem{
+				method: http.MethodGet,
+				path:   "/",
+			},
+			expected: ErrNotFound,
+		},
+		{
+			// no matching handler and middlewares was found.
+			insertItems: []*insertItem{
+				&insertItem{
+					methods:     []string{http.MethodGet},
+					path:        `/foo`,
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+			},
+			searchItem: &searchItem{
+				method: http.MethodPost,
+				path:   "/foo",
+			},
+			expected: ErrMethodNotAllowed,
+		},
+	}
+
+	for _, c := range cases {
+		tree := NewTree()
+		for _, i := range c.insertItems {
+			tree.Insert(i.methods, i.path, i.handler, i.middlewares)
+		}
+		actual, err := tree.Search(c.searchItem.method, c.searchItem.path)
+		if actual != nil {
+			t.Fatalf("actual: %v expected err: %v", actual, err)
+		}
+
+		if err != c.expected {
+			t.Fatalf("err: %v expected: %v\n", err, c.expected)
+		}
+	}
+}
+
+func TestSearchOnlyRoot(t *testing.T) {
+	tree := NewTree()
+
+	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	tree.Insert([]string{http.MethodGet}, `/`, rootHandler, []middleware{first})
+
+	cases := []caseWithFailure{
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     rootHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodGet,
+				path:   "//",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     rootHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: true,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/foo",
+			},
+			expected: nil,
+		},
+		{
+			hasError: true,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/foo/bar",
+			},
+			expected: nil,
+		},
+	}
+
+	testWithFailure(t, tree, cases)
+}
+
+func TestSearchWithoutRoot(t *testing.T) {
+	tree := NewTree()
+
+	fooHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	barHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	tree.Insert([]string{http.MethodGet}, `/foo`, fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/bar`, barHandler, []middleware{first})
+
+	cases := []caseWithFailure{
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/foo",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/bar",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     barHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: true,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/",
+			},
+			expected: nil,
+		},
+	}
+
+	testWithFailure(t, tree, cases)
+}
+
+func TestSearchCommonPrefix(t *testing.T) {
+	tree := NewTree()
+
+	fooHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	tree.Insert([]string{http.MethodGet}, `/foo`, fooHandler, []middleware{first})
+
+	cases := []caseWithFailure{
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/foo",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		// TODO: /fooで登録、/fo一致しちゃう問題
+		// {
+		// 	hasError: true,
+		// 	item: &item{
+		// 		method: http.MethodGet,
+		// 		path:   "/",
+		// 	},
+		// 	expected: nil,
+		// },
+		// {
+		// 	hasError: true,
+		// 	item: &item{
+		// 		method: http.MethodGet,
+		// 		path:   "/b",
+		// 	},
+		// 	expected: nil,
+		// },
+		// {
+		// 	hasError: true,
+		// 	item: &item{
+		// 		method: http.MethodGet,
+		// 		path:   "/f",
+		// 	},
+		// 	expected: nil,
+		// },
+		// {
+		// 	hasError: true,
+		// 	item: &item{
+		// 		method: http.MethodGet,
+		// 		path:   "/fo",
+		// 	},
+		// 	expected: nil,
+		// },
+		// {
+		// 	hasError: true,
+		// 	item: &item{
+		// 		method: http.MethodGet,
+		// 		path:   "/fooo",
+		// 	},
+		// 	expected: nil,
+		// },
+		// {
+		// 	hasError: true,
+		// 	item: &item{
+		// 		method: http.MethodGet,
+		// 		path:   "/foo/bar",
+		// 	},
+		// 	expected: nil,
+		// },
+	}
+
+	testWithFailure(t, tree, cases)
 }
 
 func TestSearchAllMethod(t *testing.T) {
@@ -104,352 +428,348 @@ func TestSearchAllMethod(t *testing.T) {
 	rootPutHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	rootPatchHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	rootDeleteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	rootOptionsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooGetHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooPostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooPutHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooPatchHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooDeleteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	fooOptionsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert([]string{http.MethodGet}, "/", rootGetHandler, []middleware{first})
-	tree.Insert([]string{http.MethodPost}, "/", rootPostHandler, []middleware{first})
-	tree.Insert([]string{http.MethodPut}, "/", rootPutHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/`, rootGetHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPost}, `/`, rootPostHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPut}, `/`, rootPutHandler, []middleware{first})
 	tree.Insert([]string{http.MethodPatch}, `/`, rootPatchHandler, []middleware{first})
 	tree.Insert([]string{http.MethodDelete}, `/`, rootDeleteHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo", fooGetHandler, []middleware{first})
-	tree.Insert([]string{http.MethodPost}, "/foo", fooPostHandler, []middleware{first})
-	tree.Insert([]string{http.MethodPut}, "/foo", fooPutHandler, []middleware{first})
+	tree.Insert([]string{http.MethodOptions}, `/`, rootOptionsHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo`, fooGetHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPost}, `/foo`, fooPostHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPut}, `/foo`, fooPutHandler, []middleware{first})
 	tree.Insert([]string{http.MethodPatch}, `/foo`, fooPatchHandler, []middleware{first})
 	tree.Insert([]string{http.MethodDelete}, `/foo`, fooDeleteHandler, []middleware{first})
+	tree.Insert([]string{http.MethodOptions}, `/foo`, fooOptionsHandler, []middleware{first})
 
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootGetHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootGetHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPost,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootPostHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootPostHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPut,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootPutHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootPutHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPatch,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootPatchHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootPatchHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodDelete,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootDeleteHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootDeleteHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
+				method: http.MethodOptions,
+				path:   "/",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     rootOptionsHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooGetHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooGetHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPost,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooPostHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooPostHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPut,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooPutHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooPutHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPatch,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooPatchHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooPatchHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodDelete,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooDeleteHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooDeleteHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodOptions,
+				path:   "/foo",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     fooOptionsHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-	}
+	testWithFailure(t, tree, cases)
 }
 
-func TestSearchPathCommon(t *testing.T) {
+func TestSearchPathCommonMultiMethods(t *testing.T) {
 	tree := NewTree()
 
-	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	fooHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	fooBarHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	rootGetHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	rootPostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	rootDeleteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	rootPatchHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	fooGetPostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	fooBarGetPostDeleteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet, http.MethodPost}, "/foo", fooHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet, http.MethodPost, http.MethodDelete}, "/foo/bar", fooBarHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/`, rootGetHandler, []middleware{first})
+	tree.Insert([]string{http.MethodPost}, `/`, rootPostHandler, []middleware{second})
+	tree.Insert([]string{http.MethodDelete}, `/`, rootDeleteHandler, []middleware{third})
+	tree.Insert([]string{http.MethodPatch}, `/`, rootPatchHandler, []middleware{first, second, third})
+	tree.Insert([]string{http.MethodGet, http.MethodPost}, `/foo`, fooGetPostHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet, http.MethodPost, http.MethodDelete}, `/foo/bar`, fooBarGetPostDeleteHandler, []middleware{first})
 
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootGetHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
+				method: http.MethodPost,
+				path:   "/",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     rootPostHandler,
+					middlewares: []middleware{second},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodDelete,
+				path:   "/",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     rootDeleteHandler,
+					middlewares: []middleware{third},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
+				method: http.MethodPatch,
+				path:   "/",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     rootPatchHandler,
+					middlewares: []middleware{first, second, third},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooGetPostHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPost,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooGetPostHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/bar",
 			},
-			expected: &Result{
-				handler:     fooBarHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooBarGetPostDeleteHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodPost,
 				path:   "/foo/bar",
 			},
-			expected: &Result{
-				handler:     fooBarHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooBarGetPostDeleteHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodDelete,
 				path:   "/foo/bar",
 			},
-			expected: &Result{
-				handler:     fooBarHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooBarGetPostDeleteHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-	}
-}
-func TestSearchWithoutRoot(t *testing.T) {
-	tree := NewTree()
-
-	fooHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	barHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-
-	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/bar", barHandler, []middleware{first})
-
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
-		{
-			item: &Item{
-				method: http.MethodGet,
-				path:   "/foo",
-			},
-			expected: &Result{
-				handler:     fooHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
-			},
-		},
-		{
-			item: &Item{
-				method: http.MethodGet,
-				path:   "/bar",
-			},
-			expected: &Result{
-				handler:     barHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-	}
+	testWithFailure(t, tree, cases)
 }
 
 func TestSearchTrailingSlash(t *testing.T) {
@@ -460,124 +780,127 @@ func TestSearchTrailingSlash(t *testing.T) {
 	barHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooBarHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo/", fooHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/bar/", barHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo/bar/", fooBarHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/`, rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/`, fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/bar/`, barHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/bar/`, fooBarHandler, []middleware{first})
 
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
+				method: http.MethodGet,
+				path:   "//",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     rootHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/",
 			},
-			expected: &Result{
-				handler:     fooHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/bar/",
 			},
-			expected: &Result{
-				handler:     barHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     barHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/bar",
 			},
-			expected: &Result{
-				handler:     barHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     barHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/bar/",
 			},
-			expected: &Result{
-				handler:     fooBarHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooBarHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/bar",
 			},
-			expected: &Result{
-				handler:     fooBarHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooBarHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-	}
+	testWithFailure(t, tree, cases)
 }
 
 func TestSearchStaticPath(t *testing.T) {
@@ -588,200 +911,202 @@ func TestSearchStaticPath(t *testing.T) {
 	barHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooBarHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/bar", barHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo/bar", fooBarHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/`, rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo`, fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/bar`, barHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/bar`, fooBarHandler, []middleware{first})
 
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/bar",
 			},
-			expected: &Result{
-				handler:     barHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     barHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: true,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/baz",
+			},
+			expected: nil,
+		},
+		{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/bar",
 			},
-			expected: &Result{
-				handler:     fooBarHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooBarHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
+		},
+		{
+			hasError: true,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/foo/baz",
+			},
+			expected: nil,
+		},
+		{
+			hasError: true,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/foo/bar/baz",
+			},
+			expected: nil,
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-	}
+	testWithFailure(t, tree, cases)
 }
 
 func TestSearchPathWithParams(t *testing.T) {
 	tree := NewTree()
 
+	idHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooIDHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooIDNameHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooIDNameDateHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
+	tree.Insert([]string{http.MethodGet}, `/:id`, idHandler, []middleware{first})
 	tree.Insert([]string{http.MethodGet}, `/foo/:id`, fooIDHandler, []middleware{first})
 	tree.Insert([]string{http.MethodGet}, `/foo/:id/:name`, fooIDNameHandler, []middleware{first})
 	tree.Insert([]string{http.MethodGet}, `/foo/:id/:name/:date`, fooIDNameDateHandler, []middleware{first})
 
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
+				method: http.MethodGet,
+				path:   "/1",
+			},
+			expected: &result{
+				actions: &action{
+					handler:     idHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
+						key:   "id",
+						value: "1",
+					},
+				},
+			},
+		},
+		{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/1",
 			},
-			expected: &Result{
-				handler: fooIDHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     fooIDHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/1/john",
 			},
-			expected: &Result{
-				handler: fooIDNameHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     fooIDNameHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
-					&Param{
+					&param{
 						key:   "name",
 						value: "john",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/1/john/2020",
 			},
-			expected: &Result{
-				handler: fooIDNameDateHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     fooIDNameDateHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
-					&Param{
+					&param{
 						key:   "name",
 						value: "john",
 					},
-					&Param{
+					&param{
 						key:   "date",
 						value: "2020",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-	}
+	testWithFailure(t, tree, cases)
 }
 
 func TestSearchPriority(t *testing.T) {
@@ -794,88 +1119,64 @@ func TestSearchPriority(t *testing.T) {
 	IDHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	IDPriorityHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/", rootPriorityHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo", fooPriorityHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/:id", IDHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/:id", IDPriorityHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/`, rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/`, rootPriorityHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo`, fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo`, fooPriorityHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/:id`, IDHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/:id`, IDPriorityHandler, []middleware{first})
 
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootPriorityHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootPriorityHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooPriorityHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooPriorityHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodGet,
 				path:   "/1",
 			},
-			expected: &Result{
-				handler: IDPriorityHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     IDPriorityHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-	}
+	testWithFailure(t, tree, cases)
 }
 
 func TestSearchRegexp(t *testing.T) {
@@ -890,310 +1191,242 @@ func TestSearchRegexp(t *testing.T) {
 	fooBarIDHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	fooBarIDNameHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	tree.Insert([]string{http.MethodGet}, "/", rootHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/`, rootHandler, []middleware{first})
 	tree.Insert([]string{http.MethodOptions}, `/:*[(.+)]`, rootWildCardHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo", fooHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo`, fooHandler, []middleware{first})
 	tree.Insert([]string{http.MethodGet}, `/foo/:id[^\d+$]`, fooIDHandler, []middleware{first})
 	tree.Insert([]string{http.MethodGet}, `/foo/:id[^\d+$]/:name[^\D+$]`, fooIDNameHandler, []middleware{first})
-	tree.Insert([]string{http.MethodGet}, "/foo/bar", fooBarHandler, []middleware{first})
+	tree.Insert([]string{http.MethodGet}, `/foo/bar`, fooBarHandler, []middleware{first})
 	tree.Insert([]string{http.MethodGet}, `/foo/bar/:id`, fooBarIDHandler, []middleware{first})
 	tree.Insert([]string{http.MethodGet}, `/foo/bar/:id/:name`, fooBarIDNameHandler, []middleware{first})
 
-	cases := []struct {
-		hasError bool
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
 			hasError: true,
-			item: &Item{
+			item: &item{
 				method: http.MethodPost,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     nil,
-				params:      Params{},
-				middlewares: []middleware{},
-			},
+			expected: nil,
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodOptions,
 				path:   "/wildcard",
 			},
-			expected: &Result{
-				handler: rootWildCardHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     rootWildCardHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "*",
 						value: "wildcard",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodOptions,
 				path:   "/1234",
 			},
-			expected: &Result{
-				handler: rootWildCardHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     rootWildCardHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "*",
 						value: "1234",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo",
 			},
-			expected: &Result{
-				handler:     fooHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
 			hasError: true,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/bar",
 			},
-			expected: &Result{
-				handler:     nil,
-				params:      Params{},
-				middlewares: []middleware{},
-			},
+			expected: nil,
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodOptions,
 				path:   "/bar",
 			},
-			expected: &Result{
-				handler: rootWildCardHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     rootWildCardHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "*",
 						value: "bar",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/1",
 			},
-			expected: &Result{
-				handler: fooIDHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     fooIDHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
 			hasError: true,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/notnumber",
 			},
-			expected: &Result{
-				handler:     nil,
-				params:      Params{},
-				middlewares: []middleware{},
-			},
+			expected: nil,
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/1/john",
 			},
-			expected: &Result{
-				handler: fooIDNameHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     fooIDNameHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
-					&Param{
+					&param{
 						key:   "name",
 						value: "john",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
 			hasError: true,
-
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/1/1",
 			},
-			expected: &Result{
-				handler:     nil,
-				params:      Params{},
-				middlewares: []middleware{},
-			},
+			expected: nil,
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/bar",
 			},
-			expected: &Result{
-				handler:     fooBarHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     fooBarHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/bar/1",
 			},
-			expected: &Result{
-				handler: fooBarIDHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     fooBarIDHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
 			hasError: true,
-			item: &Item{
+			item: &item{
 				method: http.MethodPost,
 				path:   "/foo/bar/1",
 			},
-			expected: &Result{
-				handler:     nil,
-				params:      Params{},
-				middlewares: []middleware{},
-			},
+			expected: nil,
 		},
 		{
 			hasError: false,
-			item: &Item{
+			item: &item{
 				method: http.MethodGet,
 				path:   "/foo/bar/1/john",
 			},
-			expected: &Result{
-				handler: fooBarIDNameHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     fooBarIDNameHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "id",
 						value: "1",
 					},
-					&Param{
+					&param{
 						key:   "name",
 						value: "john",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := tree.Search(c.item.method, c.item.path)
-
-		if c.hasError {
-			if err == nil {
-				t.Errorf("expected err: %v actual: %v", err, actual)
-			}
-
-			if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-				t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-			}
-
-			if len(actual.params) != len(c.expected.params) {
-				t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-			}
-
-			for i, param := range actual.params {
-				if !reflect.DeepEqual(param, c.expected.params[i]) {
-					t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-				}
-			}
-
-			if len(actual.middlewares) != len(c.expected.middlewares) {
-				t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-			}
-
-			for i, mws := range actual.middlewares {
-				if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-					t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-				}
-			}
-
-			continue
-		}
-
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
-		}
-
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
-		}
-
-		if len(actual.params) != len(c.expected.params) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
-		}
-
-		for i, param := range actual.params {
-			if !reflect.DeepEqual(param, c.expected.params[i]) {
-				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		if len(actual.middlewares) != len(c.expected.middlewares) {
-			t.Errorf("actual: %v expected: %v\n", len(actual.middlewares), len(c.expected.middlewares))
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
-			}
-		}
-
-	}
+	testWithFailure(t, tree, cases)
 }
 
 func TestSearchWildCardRegexp(t *testing.T) {
@@ -1205,74 +1438,113 @@ func TestSearchWildCardRegexp(t *testing.T) {
 	tree.Insert([]string{http.MethodOptions}, `/`, rootHandler, []middleware{first})
 	tree.Insert([]string{http.MethodOptions}, `/:*[(.+)]`, rootWildCardHandler, []middleware{first})
 
-	cases := []struct {
-		item     *Item
-		expected *Result
-	}{
+	cases := []caseWithFailure{
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodOptions,
 				path:   "/",
 			},
-			expected: &Result{
-				handler:     rootHandler,
-				params:      Params{},
-				middlewares: []middleware{first},
+			expected: &result{
+				actions: &action{
+					handler:     rootHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodOptions,
 				path:   "/wildcard",
 			},
-			expected: &Result{
-				handler: rootWildCardHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     rootWildCardHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "*",
 						value: "wildcard",
 					},
 				},
-				middlewares: []middleware{first},
 			},
 		},
 		{
-			item: &Item{
+			hasError: false,
+			item: &item{
 				method: http.MethodOptions,
 				path:   "/1234",
 			},
-			expected: &Result{
-				handler: rootWildCardHandler,
-				params: Params{
-					&Param{
+			expected: &result{
+				actions: &action{
+					handler:     rootWildCardHandler,
+					middlewares: []middleware{first},
+				},
+				params: params{
+					&param{
 						key:   "*",
 						value: "1234",
 					},
 				},
-				middlewares: []middleware{first},
 			},
+		},
+		{
+			hasError: true,
+			item: &item{
+				method: http.MethodOptions,
+				path:   "/1234/foo",
+			},
+			expected: nil,
 		},
 	}
 
+	testWithFailure(t, tree, cases)
+}
+
+func testWithFailure(t *testing.T, tree *tree, cases []caseWithFailure) {
 	for _, c := range cases {
 		actual, err := tree.Search(c.item.method, c.item.path)
-		if err != nil {
-			t.Errorf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
+
+		if c.hasError {
+			if err == nil {
+				t.Fatalf("actual: %v expected err: %v", actual, err)
+			}
+
+			if actual != c.expected {
+				t.Errorf("actual:%v expected:%v", actual, c.expected)
+			}
+
+			continue
 		}
 
-		if reflect.ValueOf(actual.handler) != reflect.ValueOf(c.expected.handler) {
-			t.Errorf("actual:%v expected:%v", actual.handler, c.expected.handler)
+		if err != nil {
+			t.Fatalf("err: %v actual: %v expected: %v\n", err, actual, c.expected)
+		}
+
+		if reflect.ValueOf(actual.actions.handler) != reflect.ValueOf(c.expected.actions.handler) {
+			t.Errorf("actual:%v expected:%v", actual.actions.handler, c.expected.actions.handler)
+		}
+
+		if len(actual.actions.middlewares) != len(c.expected.actions.middlewares) {
+			t.Errorf("actual: %v expected: %v\n", len(actual.actions.middlewares), len(c.expected.actions.middlewares))
+		}
+
+		for i, mws := range actual.actions.middlewares {
+			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.actions.middlewares[i]) {
+				t.Errorf("actual: %v expected: %v\n", mws, c.expected.actions.middlewares[i])
+			}
+		}
+
+		if len(actual.params) != len(c.expected.params) {
+			t.Errorf("actual: %v expected: %v\n", len(actual.params), len(c.expected.params))
 		}
 
 		for i, param := range actual.params {
 			if !reflect.DeepEqual(param, c.expected.params[i]) {
 				t.Errorf("actual: %v expected: %v\n", param, c.expected.params[i])
-			}
-		}
-
-		for i, mws := range actual.middlewares {
-			if reflect.ValueOf(mws) != reflect.ValueOf(c.expected.middlewares[i]) {
-				t.Errorf("actual: %v expected: %v\n", mws, c.expected.middlewares[i])
 			}
 		}
 	}
@@ -1344,19 +1616,35 @@ func TestExplodePath(t *testing.T) {
 		expected []string
 	}{
 		{
-			actual:   explodePath(strings.Split("/", pathDelimiter)),
+			actual:   explodePath(""),
 			expected: nil,
 		},
 		{
-			actual:   explodePath(strings.Split("/foo", pathDelimiter)),
+			actual:   explodePath("/"),
+			expected: nil,
+		},
+		{
+			actual:   explodePath("//"),
+			expected: nil,
+		},
+		{
+			actual:   explodePath("///"),
+			expected: nil,
+		},
+		{
+			actual:   explodePath("/foo"),
 			expected: []string{"foo"},
 		},
 		{
-			actual:   explodePath(strings.Split("/foo/bar", pathDelimiter)),
+			actual:   explodePath("/foo/bar"),
 			expected: []string{"foo", "bar"},
 		},
 		{
-			actual:   explodePath(strings.Split("/foo/bar/baz", pathDelimiter)),
+			actual:   explodePath("/foo/bar/baz"),
+			expected: []string{"foo", "bar", "baz"},
+		},
+		{
+			actual:   explodePath("/foo/bar/baz/"),
 			expected: []string{"foo", "bar", "baz"},
 		},
 	}


### PR DESCRIPTION
# Overview
There was a bug that middleware was overwritten when middleware was registered with the same path even if the methods were different.
Because there was a fundamental problem with the data structure of trie.

# Changes
- Review of trie data structure
- Improved error handling

# Impact range
Since it is an adjustment of internal logic, backward compatibility is basically maintained.

# Operational Requirements

# Related Issue
https://github.com/bmf-san/goblin/issues/28

# Supplement
