### PR TITLE
Reduce the memory allocation by refactoring explodePath method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,15 @@ test-cover: ## Run tests with cover options. ex. make test-cover OUT="c.out"
 	go test -v -race -cover -coverprofile=$(OUT) -covermode=atomic ./...
 
 .PHONY: test-benchmark
-test-benchmark: ## Run benchmark tests.
-	go test -bench=. -cpu=4 -benchmem
+test-benchmark: ## Run benchmark tests. ex. make test-benchmark CPU=4 COUNT=3
+	go test -bench=. -cpu=$(CPU) -benchmem -count=$(COUNT)
+
+.PHONY: test-benchmark-cpuprofile
+test-benchmark-cpuprofile: ## Run benchmark tests with cpuprofile and run pprof.
+	go test -bench . -cpuprofile cpu.out
+	go tool pprof -http=":8888" cpu.out
+
+.PHONY: test-benchmark-memprofile
+test-benchmark-memprofile: ## Run benchmark tests with memprofile and run pprof.
+	go test -bench . -memprofile mem.out
+	go tool pprof -http=":8889" mem.out

--- a/router_test.go
+++ b/router_test.go
@@ -333,6 +333,14 @@ func TestCleanPath(t *testing.T) {
 			expected: "/",
 		},
 		{
+			path:     "//",
+			expected: "/",
+		},
+		{
+			path:     "///",
+			expected: "/",
+		},
+		{
 			path:     "path",
 			expected: "/path",
 		},

--- a/trie.go
+++ b/trie.go
@@ -47,8 +47,6 @@ func newResult() *result {
 }
 
 const (
-	pathRoot          string = "/"
-	pathDelimiter     string = "/"
 	paramDelimiter    string = ":"
 	leftPtnDelimiter  string = "["
 	rightPtnDelimiter string = "]"
@@ -59,7 +57,7 @@ const (
 func newTree() *tree {
 	return &tree{
 		node: &node{
-			label:    pathRoot,
+			label:    "/",
 			actions:  make(map[string]*action),
 			children: make(map[string]*node),
 		},
@@ -69,7 +67,7 @@ func newTree() *tree {
 // Insert inserts a route definition to tree.
 func (t *tree) Insert(methods []string, path string, handler http.Handler, mws middlewares) error {
 	curNode := t.node
-	if path == pathRoot {
+	if path == "/" {
 		curNode.label = path
 		for _, method := range methods {
 			curNode.actions[method] = &action{
@@ -181,7 +179,7 @@ func (t *tree) Search(method string, path string) (*result, error) {
 			return nil, ErrNotFound
 		}
 	}
-	if path == pathRoot {
+	if path == "/" {
 		if len(curNode.actions) == 0 {
 			// no matching handler and middlewares was found.
 			return nil, ErrNotFound
@@ -240,14 +238,11 @@ func getParamName(label string) string {
 	return label[leftI+1 : rightI]
 }
 
-// explodePath removes an empty value in slice.
+// explodePath converts a path to a slice split　by path delimiter.
+// path expects a path processed by cleanPath.
 func explodePath(path string) []string {
-	s := strings.Split(path, pathDelimiter)
-	var r []string
-	for _, str := range s {
-		if str != "" {
-			r = append(r, str)
-		}
+	splitFn := func(c rune) bool {
+		return c == '/'
 	}
-	return r
+	return strings.FieldsFunc(path, splitFn)
 }

--- a/trie_test.go
+++ b/trie_test.go
@@ -19,7 +19,7 @@ func TestNewTree(t *testing.T) {
 	actual := newTree()
 	expected := &tree{
 		node: &node{
-			label:    pathRoot,
+			label:    "/",
 			actions:  make(map[string]*action),
 			children: make(map[string]*node),
 		},
@@ -1610,19 +1610,19 @@ func TestExplodePath(t *testing.T) {
 	}{
 		{
 			actual:   explodePath(""),
-			expected: nil,
+			expected: []string{},
 		},
 		{
 			actual:   explodePath("/"),
-			expected: nil,
+			expected: []string{},
 		},
 		{
 			actual:   explodePath("//"),
-			expected: nil,
+			expected: []string{},
 		},
 		{
 			actual:   explodePath("///"),
-			expected: nil,
+			expected: []string{},
 		},
 		{
 			actual:   explodePath("/foo"),


### PR DESCRIPTION
# Overview
I felt like I could reduce the memory allocation. 🤔 

The Search method seems to be where the bottleneck is most hidden, but the Search method's processing is a little complicated, so first improve explodePath, which seems to be the second bottleneck and has simple processing.

# Changes
Run commands, and compare results.
```sh
go test -bench=. -cpu=1 -benchmem
go test -bench . -memprofile mem.out && go tool pprof -http=":8889" mem.out
```

Before
```sh
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1         5072353               240.1 ns/op           128 B/op          4 allocs/op
BenchmarkStatic5         2491546               490.0 ns/op           384 B/op          6 allocs/op
BenchmarkStatic10        1653658               729.6 ns/op           720 B/op          7 allocs/op
BenchmarkWildCard1       1602606               747.3 ns/op           456 B/op          9 allocs/op
BenchmarkWildCard5        435784              2716 ns/op            1016 B/op         23 allocs/op
BenchmarkWildCard10       246729              5033 ns/op            1680 B/op         35 allocs/op
BenchmarkRegexp1         1647258               733.2 ns/op           456 B/op          9 allocs/op
BenchmarkRegexp5          456652              2641 ns/op            1016 B/op         23 allocs/op
BenchmarkRegexp10         251998              4780 ns/op            1680 B/op         35 allocs/op
PASS
ok      github.com/bmf-san/goblin       14.304s
```

![スクリーンショット 2022-11-03 1 00 43](https://user-images.githubusercontent.com/13291041/199539662-8f4d7b2d-267d-4c7e-87da-e01e243c7c6d.png)


After
```sh
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1         8243053               145.8 ns/op            64 B/op          2 allocs/op
BenchmarkStatic5         4207813               282.6 ns/op           128 B/op          2 allocs/op
BenchmarkStatic10        2626821               451.4 ns/op           208 B/op          2 allocs/op
BenchmarkWildCard1       1766892               685.1 ns/op           424 B/op          8 allocs/op
BenchmarkWildCard5        456736              2531 ns/op             760 B/op         19 allocs/op
BenchmarkWildCard10       254260              4621 ns/op            1168 B/op         30 allocs/op
BenchmarkRegexp1         1830240               659.5 ns/op           424 B/op          8 allocs/op
BenchmarkRegexp5          489993              2379 ns/op             760 B/op         19 allocs/op
BenchmarkRegexp10         272499              4337 ns/op            1168 B/op         30 allocs/op
PASS
ok      github.com/bmf-san/goblin       13.572s
```

![スクリーンショット 2022-11-03 1 18 15](https://user-images.githubusercontent.com/13291041/199543868-e6826ee9-c9b0-443f-b4ee-5c6e14ef66c9.png)


# Impact range
No specification change.

# Operational Requirements
N/A

# Related Issue
N/A

# Supplement
N/A