### PR TITLE
[update] stopped using pointers for params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ launch.json
 .DS_STORE
 .vscode/
 goblin
+goblin.test
 debug.test
 *.out

--- a/context_test.go
+++ b/context_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestGetParam(t *testing.T) {
 	params := &params{
-		&param{
+		param{
 			key:   "id",
 			value: "123",
 		},
-		&param{
+		param{
 			key:   "name",
 			value: "john",
 		},

--- a/trie.go
+++ b/trie.go
@@ -33,7 +33,7 @@ type param struct {
 }
 
 // params is parameters.
-type params []*param
+type params []param
 
 const (
 	paramDelimiter    string = ":"
@@ -148,7 +148,7 @@ func (t *tree) Search(method string, path string) (*action, params, error) {
 				}
 				if reg.Match([]byte(p)) {
 					pn := getParamName(c)
-					params = append(params, &param{
+					params = append(params, param{
 						key:   pn,
 						value: p,
 					})

--- a/trie_test.go
+++ b/trie_test.go
@@ -53,14 +53,14 @@ func TestSearchFailure(t *testing.T) {
 	fooHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
 	cases := []struct {
-		insertItems []*insertItem
+		insertItems []insertItem
 		searchItem  *searchItem
 		expected    error
 	}{
 		{
 			// no matching path was found.
-			insertItems: []*insertItem{
-				&insertItem{
+			insertItems: []insertItem{
+				{
 					methods:     []string{http.MethodGet},
 					path:        `/foo`,
 					handler:     fooHandler,
@@ -75,8 +75,8 @@ func TestSearchFailure(t *testing.T) {
 		},
 		{
 			// no matching param was found.
-			insertItems: []*insertItem{
-				&insertItem{
+			insertItems: []insertItem{
+				{
 					methods:     []string{http.MethodGet},
 					path:        `/foo/:id[^\d+$]`,
 					handler:     fooHandler,
@@ -91,8 +91,8 @@ func TestSearchFailure(t *testing.T) {
 		},
 		{
 			// no matching param was found.
-			insertItems: []*insertItem{
-				&insertItem{
+			insertItems: []insertItem{
+				{
 					methods:     []string{http.MethodGet},
 					path:        `/foo`,
 					handler:     fooHandler,
@@ -107,8 +107,8 @@ func TestSearchFailure(t *testing.T) {
 		},
 		{
 			// no matching handler and middlewares was found.
-			insertItems: []*insertItem{
-				&insertItem{
+			insertItems: []insertItem{
+				{
 					methods:     []string{http.MethodGet},
 					path:        `/foo`,
 					handler:     fooHandler,
@@ -123,8 +123,8 @@ func TestSearchFailure(t *testing.T) {
 		},
 		{
 			// no matching handler and middlewares was found.
-			insertItems: []*insertItem{
-				&insertItem{
+			insertItems: []insertItem{
+				{
 					methods:     []string{http.MethodGet},
 					path:        `/foo`,
 					handler:     fooHandler,
@@ -892,7 +892,7 @@ func TestSearchPathWithParams(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
@@ -909,7 +909,7 @@ func TestSearchPathWithParams(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
@@ -926,11 +926,11 @@ func TestSearchPathWithParams(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
-				&param{
+				param{
 					key:   "name",
 					value: "john",
 				},
@@ -947,15 +947,15 @@ func TestSearchPathWithParams(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
-				&param{
+				param{
 					key:   "name",
 					value: "john",
 				},
-				&param{
+				param{
 					key:   "date",
 					value: "2020",
 				},
@@ -1019,7 +1019,7 @@ func TestSearchPriority(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
@@ -1084,7 +1084,7 @@ func TestSearchRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "*",
 					value: "wildcard",
 				},
@@ -1101,7 +1101,7 @@ func TestSearchRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "*",
 					value: "1234",
 				},
@@ -1139,7 +1139,7 @@ func TestSearchRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "*",
 					value: "bar",
 				},
@@ -1156,7 +1156,7 @@ func TestSearchRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
@@ -1182,11 +1182,11 @@ func TestSearchRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
-				&param{
+				param{
 					key:   "name",
 					value: "john",
 				},
@@ -1224,7 +1224,7 @@ func TestSearchRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
@@ -1250,11 +1250,11 @@ func TestSearchRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "id",
 					value: "1",
 				},
-				&param{
+				param{
 					key:   "name",
 					value: "john",
 				},
@@ -1298,7 +1298,7 @@ func TestSearchWildCardRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "*",
 					value: "wildcard",
 				},
@@ -1315,7 +1315,7 @@ func TestSearchWildCardRegexp(t *testing.T) {
 				middlewares: []middleware{first},
 			},
 			expectedParams: params{
-				&param{
+				param{
 					key:   "*",
 					value: "1234",
 				},


### PR DESCRIPTION
# Overview
![スクリーンショット 2022-11-12 12 57 44](https://user-images.githubusercontent.com/13291041/201456048-3cf605b8-ea73-4013-a564-39f81f72f278.png)

![スクリーンショット 2022-11-12 12 58 40](https://user-images.githubusercontent.com/13291041/201456083-b754597a-0a00-4a0c-a846-373a8d85fd1a.png)


# Changes
- Stopped using pointers for params
- Fix tests

Before
```sh
go test -bench=. -cpu=1 -benchmem -count=3
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1         9479496               130.1 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1         9238120               129.5 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1         9217893               130.2 ns/op            32 B/op          1 allocs/op
BenchmarkStatic5         4274468               280.7 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4251072               281.0 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4269682               281.9 ns/op            96 B/op          1 allocs/op
BenchmarkStatic10        2536338               472.8 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2542339               467.1 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2573580               467.8 ns/op           176 B/op          1 allocs/op
BenchmarkWildCard1       1774546               673.3 ns/op           392 B/op          7 allocs/op
BenchmarkWildCard1       1817253               668.5 ns/op           392 B/op          7 allocs/op
BenchmarkWildCard1       1776864               665.7 ns/op           392 B/op          7 allocs/op
BenchmarkWildCard5        471318              2510 ns/op             728 B/op         18 allocs/op
BenchmarkWildCard5        465484              2570 ns/op             728 B/op         18 allocs/op
BenchmarkWildCard5        475708              2506 ns/op             728 B/op         18 allocs/op
BenchmarkWildCard10       252789              4745 ns/op            1136 B/op         29 allocs/op
BenchmarkWildCard10       252019              4729 ns/op            1136 B/op         29 allocs/op
BenchmarkWildCard10       264942              4687 ns/op            1136 B/op         29 allocs/op
BenchmarkRegexp1         1856025               648.6 ns/op           392 B/op          7 allocs/op
BenchmarkRegexp1         1839674               647.2 ns/op           392 B/op          7 allocs/op
BenchmarkRegexp1         1809133               647.7 ns/op           392 B/op          7 allocs/op
BenchmarkRegexp5          497331              2396 ns/op             728 B/op         18 allocs/op
BenchmarkRegexp5          496726              2378 ns/op             728 B/op         18 allocs/op
BenchmarkRegexp5          524958              2407 ns/op             728 B/op         18 allocs/op
BenchmarkRegexp10         266846              4500 ns/op            1136 B/op         29 allocs/op
BenchmarkRegexp10         266263              4584 ns/op            1136 B/op         29 allocs/op
BenchmarkRegexp10         265555              4497 ns/op            1136 B/op         29 allocs/op
PASS
ok      github.com/bmf-san/goblin       40.125s
```

After
operation times and allocs/op has been improved, but ns/op and B/op are a little suspicious. 🤔 

```sh
go test -bench=. -cpu=1 -benchmem -count=3
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1         9416574               129.5 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1         8315736               128.9 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1         9438574               128.1 ns/op            32 B/op          1 allocs/op
BenchmarkStatic5         4334941               278.0 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4338223               277.8 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4298078               277.4 ns/op            96 B/op          1 allocs/op
BenchmarkStatic10        2554701               466.5 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2543463               464.2 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2565387               466.1 ns/op           176 B/op          1 allocs/op
BenchmarkWildCard1       1862164               645.0 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard1       1858161               647.9 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard1       1824388               662.0 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard5        476378              2725 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard5        492577              2580 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard5        396484              2753 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard10       257245              4917 ns/op            1560 B/op         19 allocs/op
BenchmarkWildCard10       227640              4790 ns/op            1560 B/op         19 allocs/op
BenchmarkWildCard10       256834              5053 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp1         1898145               635.4 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp1         1812205               640.4 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp1         1909863               670.1 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp5          424128              2494 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp5          519808              2550 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp5          507451              2448 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp10         262260              4419 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp10         259952              4362 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp10         283237              4340 ns/op            1560 B/op         19 allocs/op
PASS
ok      github.com/bmf-san/goblin       39.987s
```

# Impact range
No specification changes.
# Operational Requirements
N/A

# Related Issue
N/A

# Supplement
N/A
