### PR TITLE
Refactoring router receiver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,59 +20,49 @@ jobs:
       - checkout
       - run:
           name: "Go version"
-          command: >
-            go version
+          command: go version
       - run:
           name: "Fetch dependencies"
-          command: >
-            go mod download
-      - run:
-          name: "Install tools"
-          command: >
-            if [[ << parameters.version >> = 1.18 ]]; then
-              make install-tools
-            fi
+          command: go mod download
       - run:
           name: "Run gofmt"
-          command: >
-            make gofmt
+          command: make gofmt
       - run:
           name: "Run vet"
-          command: >
-            make vet
-      - run:
-          name: "Run errcheck"
-          command: >
-            if [[ << parameters.version >> = 1.18 ]]; then
-              make errcheck
-            fi
-      - run:
-          name: "Run go staticcheck"
-          command: >
-            if [[ << parameters.version >> = 1.18 ]]; then
-              make staticcheck
-            fi
-      - run:
-          name: "Run gosec"
-          command: >
-            if [[ << parameters.version >> = 1.18 ]]; then
-              make gosec
-            fi
+          command: make vet
       - run:
           name: "Run go test"
-          command: >
-            make test
+          command: make test
+      - when:
+          condition:
+            or:
+              - equal: [ '1.19', << parameters.version >> ]
+              - equal: [ '1.18', << parameters.version >> ]
+          steps:
+            - run:
+                name: "Install tools"
+                command: make install-tools
+            - run:
+                name: "Run errcheck"
+                command: make errcheck
+            - run:
+                name: "Run go staticcheck"
+                command: make staticcheck
+            - run:
+                name: "Run gosec"
+                command: make gosec
+            - run:
+                name: "Run benchstat"
+                command: make benchstat
       - run:
           name: Build go
           command: go build
       - run:
           name: Create a temporary directory for artifacts
-          command: |
-              mkdir -p /tmp/artifacts
+          command: mkdir -p /tmp/artifacts
       - run:
           name: Generate coverage
-          command: |
-              make test-cover OUT=<< parameters.version >>.out
+          command: make test-cover OUT=<< parameters.version >>.out
       - codecov/upload:
           file: ./<< parameters.version >>.out
 
@@ -82,4 +72,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ["1.19", "1.18", "1.17", "1.16", "1.15"]
+              version: ["1.19", "1.18", "1.17", "1.16"]

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,6 +4,5 @@
 2. Create a feature branch
 3. Commit your changes
 4. Rebase your local changes against the master branch
-5. Run test suite with the `go test ./...` command and confirm that it passes
-6. Run `gofmt -s`
-7. Create new Pull Request
+5. Fix your codes if CI failed.
+6. Create new Pull Request

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,32 +4,23 @@ about: Create a report to help us improve
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+# Description
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+# Expected Behavior
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+# Current Behavior
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+# Steps to Reproduce
+1.
+2.
+3.
+4.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+# Environment
+<!--- Tell us your go version. -->
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+# Possible Solution
+<!--- Not obligatory, but tell us if you have any ideas. -->
 
-**Additional context**
-Add any other context about the problem here.
+# Possible Implementation
+<!--- Not obligatory, but tell us if you have any ideas. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,14 +4,9 @@ about: Suggest an idea for this project
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+# Description
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+# Describe the feature you'd like to request
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+# Describe the solution you'd like
+<!--- Not obligatory -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,7 @@
+---
+name: Question
+about: Create a report to ask any quetions.
+
+---
+
+# Question

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Overview
+# Description
 
 # Changes
 
@@ -7,5 +7,7 @@
 # Operational Requirements
 
 # Related Issue
+<!--- Not obligatory, but write any issues if exists it -->
 
 # Supplement
+<!--- Not obligatory -->

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ endif
 ifeq ($(shell command -v gosec 2> /dev/null),)
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
 endif
+ifeq ($(shell command -v benchstat 2> /dev/null),)
+	go install golang.org/x/perf/cmd/benchstat@latest
+endif
 
 .PHONY: gofmt
 gofmt: ## Run gofmt.
@@ -65,3 +68,11 @@ test-benchmark-cpuprofile: ## Run benchmark tests with cpuprofile and run pprof.
 test-benchmark-memprofile: ## Run benchmark tests with memprofile and run pprof.
 	go test -bench . -memprofile mem.out
 	go tool pprof -http=":8889" mem.out
+
+benchstat: ## Run benchstat
+	$(eval BRANCH := $(shell git rev-parse --abbrev-ref HEAD))
+	git checkout master
+	go test -bench . -count 1 > old.out
+	git checkout $(BRANCH)
+	go test -bench . -count 1 > new.out
+	benchstat old.out new.out

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A golang http router based on trie tree.
 
 # Features
-- Support Go1.19 >= 1.15
+- Support Go1.19 >= 1.16
 - Easy to use
 - Lightweight
 - Fully compatible with net/http

--- a/router.go
+++ b/router.go
@@ -33,40 +33,40 @@ var (
 )
 
 // NewRouter creates a new router.
-func NewRouter() *Router {
-	return &Router{
+func NewRouter() Router {
+	return Router{
 		tree: newTree(),
 	}
 }
 
 // Use sets middlewares.
-func (r *Router) Use(mws ...middleware) *Router {
+func (r Router) Use(mws ...middleware) Router {
 	nm := NewMiddlewares(mws)
 	tmpRoute.middlewares = nm
 	return r
 }
 
-func (r *Router) Methods(methods ...string) *Router {
+func (r Router) Methods(methods ...string) Router {
 	tmpRoute.methods = append(tmpRoute.methods, methods...)
 	return r
 }
 
 // Handler sets a handler.
-func (r *Router) Handler(path string, handler http.Handler) {
+func (r Router) Handler(path string, handler http.Handler) {
 	tmpRoute.handler = handler
 	tmpRoute.path = path
 	r.Handle()
 }
 
 // Handle handles a route.
-func (r *Router) Handle() {
+func (r Router) Handle() {
 	r.tree.Insert(tmpRoute.methods, tmpRoute.path, tmpRoute.handler, tmpRoute.middlewares)
 	tmpRoute = &route{}
 }
 
 // ServeHTTP dispatches the request to the handler whose
 // pattern most closely matches the request URL.
-func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (r Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	method := req.Method
 	path := cleanPath(req.URL.Path)
 	action, params, err := r.tree.Search(method, path)

--- a/router_test.go
+++ b/router_test.go
@@ -2,7 +2,7 @@ package goblin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -11,7 +11,7 @@ import (
 
 func TestNewRouter(t *testing.T) {
 	actual := NewRouter()
-	expected := &Router{
+	expected := Router{
 		tree: newTree(),
 	}
 
@@ -217,7 +217,7 @@ func TestRouter(t *testing.T) {
 			t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
 		}
 
-		recBody, _ := ioutil.ReadAll(rec.Body)
+		recBody, _ := io.ReadAll(rec.Body)
 		body := string(recBody)
 		if body != c.body {
 			t.Errorf("actual: %v expected: %v\n", body, c.body)
@@ -302,7 +302,7 @@ func TestCustomErrorHandler(t *testing.T) {
 			t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
 		}
 
-		recBody, _ := ioutil.ReadAll(rec.Body)
+		recBody, _ := io.ReadAll(rec.Body)
 		body := string(recBody)
 		if body != c.body {
 			t.Errorf("actual: %v expected: %v\n", body, c.body)


### PR DESCRIPTION
# Overview
Improve perfomance by stopped using Router pointer receiver.

# Changes
- Stopped using Router pointer receiver
- Add benchstat tool
- Fix bugs ing CI jobs
  - Required jobs were not running in go1.19 
- End of support go1.15
- Update issue templates

Before
```sh
go test -bench=. -cpu=1 -benchmem -count=3
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1         9382904               128.2 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1         9410863               127.6 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1         9417586               126.6 ns/op            32 B/op          1 allocs/op
BenchmarkStatic5         4367858               274.8 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4368003               286.1 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4197505               276.0 ns/op            96 B/op          1 allocs/op
BenchmarkStatic10        2445247               496.3 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2535044               480.3 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2482634               470.7 ns/op           176 B/op          1 allocs/op
BenchmarkWildCard1       1874241               640.1 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard1       1738502               703.2 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard1       1851855               719.1 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard5        507542              2472 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard5        486055              2470 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard5        522135              2443 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard10       259974              4631 ns/op            1560 B/op         19 allocs/op
BenchmarkWildCard10       256924              4629 ns/op            1560 B/op         19 allocs/op
BenchmarkWildCard10       261069              4609 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp1         1963184               615.9 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp1         1950442               611.6 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp1         1970739               613.0 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp5          533304              2309 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp5          534800              2326 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp5          517088              2325 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp10         289285              4329 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp10         276583              4330 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp10         272575              4527 ns/op            1560 B/op         19 allocs/op
PASS
ok      github.com/bmf-san/goblin       40.444s
```

After
```sh
go test -bench=. -cpu=1 -benchmem -count=3
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1        10072951               123.4 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1        10089045               119.7 ns/op            32 B/op          1 allocs/op
BenchmarkStatic1         9869005               119.5 ns/op            32 B/op          1 allocs/op
BenchmarkStatic5         4678380               255.9 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4672666               257.4 ns/op            96 B/op          1 allocs/op
BenchmarkStatic5         4618848               253.0 ns/op            96 B/op          1 allocs/op
BenchmarkStatic10        2847400               427.5 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2854250               422.3 ns/op           176 B/op          1 allocs/op
BenchmarkStatic10        2722155               434.5 ns/op           176 B/op          1 allocs/op
BenchmarkWildCard1       1903887               632.0 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard1       1888086               626.7 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard1       1914217               633.9 ns/op           384 B/op          6 allocs/op
BenchmarkWildCard5        500449              2394 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard5        533448              2486 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard5        487317              2464 ns/op             928 B/op         13 allocs/op
BenchmarkWildCard10       271914              4541 ns/op            1560 B/op         19 allocs/op
BenchmarkWildCard10       266788              4601 ns/op            1560 B/op         19 allocs/op
BenchmarkWildCard10       260335              4581 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp1         1887534               616.6 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp1         1947963               612.8 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp1         1959728               605.0 ns/op           384 B/op          6 allocs/op
BenchmarkRegexp5          517082              2300 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp5          538726              2302 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp5          522044              2307 ns/op             928 B/op         13 allocs/op
BenchmarkRegexp10         278421              4287 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp10         287530              4325 ns/op            1560 B/op         19 allocs/op
BenchmarkRegexp10         281001              4393 ns/op            1560 B/op         19 allocs/op
PASS
ok      github.com/bmf-san/goblin       39.821s
```

# Impact range
Method using Router's pointer receiver.

# Operational Requirements
N/A

# Related Issue
https://github.com/bmf-san/goblin/issues/70

# Supplement
N/A
