### PR TITLE
Minor refactoring

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,18 +4,17 @@ import (
 	"context"
 )
 
-type key int
+// paramsKey represents the key for parameters
+type paramsKey struct{}
 
-const (
-	// ParamsKey is the key in a request context.
-	ParamsKey key = iota
-)
+// ParamsKey is the request context key under which URL params are stored.
+var ParamsKey = paramsKey{}
 
 // GetParam gets parameters from request.
 func GetParam(ctx context.Context, name string) string {
 	params, _ := ctx.Value(ParamsKey).([]Param)
 
-	for i := range params {
+	for i := 0; i < len(params); i++ {
 		if params[i].key == name {
 			return params[i].value
 		}

--- a/middleware.go
+++ b/middleware.go
@@ -10,14 +10,16 @@ type middleware func(http.Handler) http.Handler
 // middlewares represents the plural of middleware.
 type middlewares []middleware
 
+// NewMiddlewares creates a new middlewares.
 func NewMiddlewares(mws middlewares) middlewares {
 	return append([]middleware(nil), mws...)
 }
 
 // then executes middlewares.
 func (mws middlewares) then(h http.Handler) http.Handler {
-	for i := range mws {
-		h = mws[len(mws)-1-i](h)
+	l := len(mws)
+	for i := 0; i < l; i++ {
+		h = mws[l-1-i](h)
 	}
 	return h
 }


### PR DESCRIPTION
# Description
As a title.

# Changes
Some changes for improving performance.

before
```sh
go test -bench=. -cpu=1 -benchmem -count=1
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1         9703232               119.8 ns/op            32 B/op          1 allocs/op
BenchmarkStatic5         4622125               254.3 ns/op            96 B/op          1 allocs/op
BenchmarkStatic10        2833615               426.2 ns/op           176 B/op          1 allocs/op
BenchmarkWildCard1       1898692               630.2 ns/op           352 B/op          5 allocs/op
BenchmarkWildCard5        498434              2323 ns/op             559 B/op          9 allocs/op
BenchmarkWildCard10       289339              4244 ns/op             801 B/op         14 allocs/op
BenchmarkRegexp1         1998573               600.1 ns/op           352 B/op          5 allocs/op
BenchmarkRegexp5          589863              2205 ns/op             559 B/op          9 allocs/op
BenchmarkRegexp10         310650              4092 ns/op             807 B/op         14 allocs/op
PASS
ok      github.com/bmf-san/goblin       13.604s
```

after
```sh
go test -bench=. -cpu=1 -benchmem -count=1
goos: darwin
goarch: amd64
pkg: github.com/bmf-san/goblin
cpu: VirtualApple @ 2.50GHz
BenchmarkStatic1        10376299               119.2 ns/op            32 B/op          1 allocs/op
BenchmarkStatic5         4794303               261.0 ns/op            96 B/op          1 allocs/op
BenchmarkStatic10        2781861               428.4 ns/op           176 B/op          1 allocs/op
BenchmarkWildCard1       2110044               567.3 ns/op           352 B/op          5 allocs/op
BenchmarkWildCard5        583000              2035 ns/op             559 B/op          9 allocs/op
BenchmarkWildCard10       338418              3643 ns/op             802 B/op         14 allocs/op
BenchmarkRegexp1         2148955               567.7 ns/op           352 B/op          5 allocs/op
BenchmarkRegexp5          602371              2026 ns/op             559 B/op          9 allocs/op
BenchmarkRegexp10         315440              3626 ns/op             801 B/op         14 allocs/op
PASS
ok      github.com/bmf-san/goblin       13.258s
```

# Impact range
No specification changes.

# Operational Requirements
N/A

# Related Issue
N/A

# Supplement
N/A
