### PR TITLE
Refactoring params and others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ goblin
 goblin.test
 debug.test
 *.out
+__debug_bin

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-benchmark-memprofile: ## Run benchmark tests with memprofile and run pprof.
 benchstat: ## Run benchstat
 	$(eval BRANCH := $(shell git rev-parse --abbrev-ref HEAD))
 	git checkout master
-	go test -bench . -benchmem -count 1 > old.out
+	go test -bench . -benchmem -cpu=1 -count=1 > old.out
 	git checkout $(BRANCH)
-	go test -bench . -benchmem -count 1 > new.out
+	go test -bench . -benchmem -cpu=1 -count=1 > new.out
 	benchstat old.out new.out

--- a/_examples/main.go
+++ b/_examples/main.go
@@ -19,6 +19,14 @@ func customMethodAllowed() http.Handler {
 	})
 }
 
+func global(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "global: before\n")
+		next.ServeHTTP(w, r)
+		fmt.Fprintf(w, "global: after\n")
+	})
+}
+
 func first(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "first: before\n")
@@ -47,6 +55,7 @@ func main() {
 	r := goblin.NewRouter()
 	r.NotFoundHandler = customMethodNotFound()
 	r.MethodNotAllowedHandler = customMethodAllowed()
+	r.UseGlobal(global)
 
 	r.Methods(http.MethodGet).Use(first).Handler(`/middleware`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "/middleware\n")
@@ -75,24 +84,24 @@ func main() {
 	r.Methods(http.MethodGet).Handler(`/foo/bar/:id`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		fmt.Fprint(w, "/foo/bar/:id\n")
-		fmt.Fprintf(w, "/foo/bar/%v", id)
+		fmt.Fprintf(w, "/foo/bar/%v\n", id)
 	}))
 	r.Methods(http.MethodGet).Handler(`/foo/bar/:id/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		name := goblin.GetParam(r.Context(), "name")
 		fmt.Fprint(w, "/foo/bar/:id/:name\n")
-		fmt.Fprintf(w, "/foo/bar/%v/%v", id, name)
+		fmt.Fprintf(w, "/foo/bar/%v/%v\n", id, name)
 	}))
 	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		fmt.Fprint(w, "/foo/:id[^\\d+$]\n")
-		fmt.Fprintf(w, "/foo/%v", id)
+		fmt.Fprintf(w, "/foo/%v\n", id)
 	}))
 	r.Methods(http.MethodGet).Handler(`/foo/:id[^\d+$]/:name`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := goblin.GetParam(r.Context(), "id")
 		name := goblin.GetParam(r.Context(), "name")
 		fmt.Fprint(w, "/foo/:id[^\\d+$]/:name\n")
-		fmt.Fprintf(w, "/foo/%v/%v", id, name)
+		fmt.Fprintf(w, "/foo/%v/%v\n", id, name)
 	}))
 
 	http.ListenAndServe(":9999", r)

--- a/trie_test.go
+++ b/trie_test.go
@@ -12,7 +12,7 @@ func TestNewTree(t *testing.T) {
 		node: &node{
 			label:    "/",
 			actions:  make(map[string]*action),
-			children: make(map[string]*node),
+			children: []*node{},
 		},
 	}
 


### PR DESCRIPTION
# Description
For performance tuning.

# Changes
- moved the creation process of the pool of params and set capacity
- changed the data structure of children that node struct has
- updated _example/main.go

Benchmark results.
```sh
go test -bench=. -cpu=1 -benchmem -count=1
goos: darwin
goarch: arm64
pkg: github.com/bmf-san/goblin
BenchmarkSetRoutes1  	1000000000	         0.0000027 ns/op	       0 B/op	       0 allocs/op
BenchmarkSetRoutes5  	1000000000	         0.0000022 ns/op	       0 B/op	       0 allocs/op
BenchmarkSetRoutes10 	1000000000	         0.0000025 ns/op	       0 B/op	       0 allocs/op
BenchmarkStatic1     	17289736	        61.54 ns/op	       0 B/op	       0 allocs/op
BenchmarkStatic5     	 6827828	       180.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkStatic10    	 3529551	       359.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkWildCard1   	 5931859	       204.4 ns/op	     328 B/op	       3 allocs/op
BenchmarkWildCard5   	 2600925	       461.9 ns/op	     408 B/op	       3 allocs/op
BenchmarkWildCard10  	 1496074	       822.3 ns/op	     600 B/op	       3 allocs/op
BenchmarkRegexp1     	 3727276	       315.6 ns/op	     336 B/op	       4 allocs/op
BenchmarkRegexp5     	 1000000	      1045 ns/op	     459 B/op	       8 allocs/op
BenchmarkRegexp10    	  667413	      1862 ns/op	     694 B/op	      13 allocs/op
PASS
ok  	github.com/bmf-san/goblin	13.267s
```

# Impact range
No specification changes.

# Operational Requirements
N/A

# Related Issue
N/A

# Supplement
<!--- Not obligatory -->
