### PR TITLE
Change tree type in router struct

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestNewRouter(t *testing.T) {
 	actual := NewRouter()
-	expected := Router{
-		tree: newTree(),
+	expected := &Router{
+		tree: map[string]*tree{},
 	}
 
 	if !reflect.DeepEqual(actual, expected) {

--- a/trie.go
+++ b/trie.go
@@ -19,8 +19,8 @@ type tree struct {
 // node is a node of tree.
 type node struct {
 	label    string
-	actions  map[string]*action // key is method
-	children []*node            // key is label of next nodes
+	action   *action // key is method
+	children []*node // key is label of next nodes
 }
 
 // action is an action.
@@ -41,7 +41,7 @@ func newTree() *tree {
 	return &tree{
 		node: &node{
 			label:    "/",
-			actions:  make(map[string]*action),
+			action:   &action{},
 			children: []*node{},
 		},
 	}
@@ -77,17 +77,15 @@ func (n *node) getChild(label string) *node {
 }
 
 // Insert inserts a route definition to tree.
-func (t *tree) Insert(methods []string, path string, handler http.Handler, mws middlewares) {
+func (t *tree) Insert(path string, handler http.Handler, mws middlewares) {
 	path = cleanPath(path)
 	curNode := t.node
 
 	if path == "/" {
 		curNode.label = path
-		for i := 0; i < len(methods); i++ {
-			curNode.actions[methods[i]] = &action{
-				middlewares: mws,
-				handler:     handler,
-			}
+		curNode.action = &action{
+			middlewares: mws,
+			handler:     handler,
 		}
 		return
 	}
@@ -134,7 +132,7 @@ func (t *tree) Insert(methods []string, path string, handler http.Handler, mws m
 		if nextNode == nil {
 			child := &node{
 				label:    l,
-				actions:  make(map[string]*action),
+				action:   &action{},
 				children: []*node{},
 			}
 			curNode.children = append(curNode.children, child)
@@ -149,11 +147,9 @@ func (t *tree) Insert(methods []string, path string, handler http.Handler, mws m
 		// If there is already registered data, overwrite it.
 		if i == cnt-1 {
 			curNode.label = l
-			for j := 0; j < len(methods); j++ {
-				curNode.actions[methods[j]] = &action{
-					middlewares: mws,
-					handler:     handler,
-				}
+			curNode.action = &action{
+				middlewares: mws,
+				handler:     handler,
 			}
 			break
 		}
@@ -195,11 +191,11 @@ func (rc *regCache) getReg(ptn string) (*regexp.Regexp, error) {
 var regC = &regCache{}
 
 // Search searches a path from a tree.
-func (t *tree) Search(method string, path string) (*action, []Param, error) {
+func (t *tree) Search(path string) (*action, []Param, error) {
 	path = cleanPath(path)
 	curNode := t.node
 
-	if path == "/" && curNode.actions[method] == nil {
+	if path == "/" && curNode.action == nil {
 		return nil, nil, ErrNotFound
 	}
 
@@ -297,15 +293,15 @@ func (t *tree) Search(method string, path string) (*action, []Param, error) {
 		}
 	}
 
-	actions := curNode.actions[method]
-	if actions == nil {
+	action := curNode.action
+	if action.handler == nil {
 		// no matching handler and middlewares was found.
-		return nil, nil, ErrMethodNotAllowed
+		return nil, nil, ErrNotFound
 	}
 	if params == nil {
-		return actions, nil, nil
+		return action, nil, nil
 	}
-	return actions, *params, nil
+	return action, *params, nil
 }
 
 // getPattern gets a pattern from a label.

--- a/trie.go
+++ b/trie.go
@@ -110,14 +110,6 @@ func (t *tree) Insert(path string, handler http.Handler, mws middlewares) {
 			// ex. foo → foo
 			l = path
 		}
-		if idx > 0 {
-			// ex. foo/bar/baz → foo
-			l = path[:idx]
-		}
-		if idx == -1 {
-			// ex. foo → foo
-			l = path
-		}
 
 		nextNode := curNode.getChild(l)
 		if nextNode != nil {
@@ -212,14 +204,6 @@ func (t *tree) Search(path string) (*action, []Param, error) {
 		}
 
 		idx := strings.Index(path, "/")
-		if idx > 0 {
-			// ex. foo/bar/baz → foo
-			l = path[:idx]
-		}
-		if idx == -1 {
-			// ex. foo → foo
-			l = path
-		}
 		if idx > 0 {
 			// ex. foo/bar/baz → foo
 			l = path[:idx]

--- a/trie.go
+++ b/trie.go
@@ -102,13 +102,10 @@ func (t *tree) Insert(path string, handler http.Handler, mws middlewares) {
 		}
 
 		idx := strings.Index(path, "/")
+		l = path
 		if idx > 0 {
 			// ex. foo/bar/baz → foo
 			l = path[:idx]
-		}
-		if idx == -1 {
-			// ex. foo → foo
-			l = path
 		}
 
 		nextNode := curNode.getChild(l)
@@ -204,13 +201,11 @@ func (t *tree) Search(path string) (*action, []Param, error) {
 		}
 
 		idx := strings.Index(path, "/")
+		// ex. foo → foo
+		l = path
 		if idx > 0 {
 			// ex. foo/bar/baz → foo
 			l = path[:idx]
-		}
-		if idx == -1 {
-			// ex. foo → foo
-			l = path
 		}
 
 		cc := curNode.children
@@ -228,7 +223,6 @@ func (t *tree) Search(path string) (*action, []Param, error) {
 		if nextNode != nil {
 			curNode = nextNode
 			if idx > 0 {
-				l = path[:idx]
 				// foo/bar/baz → /bar/baz
 				path = path[idx:]
 			}


### PR DESCRIPTION
# Description
see: https://github.com/bmf-san/goblin/issues/84

# Changes
changes tree type in router struct.

benchmark tests
```sh
goos: darwin
goarch: arm64
pkg: github.com/bmf-san/goblin
BenchmarkSetRoutes1  	1000000000	         0.0000022 ns/op	       0 B/op	       0 allocs/op
BenchmarkSetRoutes5  	1000000000	         0.0000018 ns/op	       0 B/op	       0 allocs/op
BenchmarkSetRoutes10 	1000000000	         0.0000025 ns/op	       0 B/op	       0 allocs/op
BenchmarkStatic1     	18641005	        57.88 ns/op	       0 B/op	       0 allocs/op
BenchmarkStatic5     	 6875048	       176.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkStatic10    	 3714705	       359.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkWildCard1   	 5812250	       204.0 ns/op	     328 B/op	       3 allocs/op
BenchmarkWildCard5   	 2605432	       467.2 ns/op	     408 B/op	       3 allocs/op
BenchmarkWildCard10  	 1501742	       853.4 ns/op	     609 B/op	       3 allocs/op
BenchmarkRegexp1     	 3698962	       338.7 ns/op	     336 B/op	       4 allocs/op
BenchmarkRegexp5     	 1000000	      1122 ns/op	     460 B/op	       8 allocs/op
BenchmarkRegexp10    	  647394	      1910 ns/op	     694 B/op	      13 allocs/op
PASS
ok  	github.com/bmf-san/goblin	13.507s

```

# Impact range
No specification changes

# Operational Requirements
N/A

# Related Issue
https://github.com/bmf-san/goblin/issues/84

# Supplement
N/A
