### PR TITLE
Update go version 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,4 +72,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ["1.19", "1.18", "1.17", "1.16"]
+              version: ["1.20", "1.19", "1.18", "1.17", "1.16"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A golang http router based on trie tree.
 
 # Features
-- Support Go1.19 >= 1.16
+- Support Go1.20 >= 1.16
 - Easy to use
 - Lightweight
 - Fully compatible with net/http

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bmf-san/goblin
 
-go 1.19
+go 1.20


### PR DESCRIPTION
# Description
go 1.20 is released. 

https://go.dev/doc/go1.20

# Changes
Support go 1.20.

# Impact range

# Operational Requirements

# Related Issue
<!--- Not obligatory, but write any issues if exists it -->

# Supplement
<!--- Not obligatory -->
