### PR TITLE
Fix go version using staticcheck.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ jobs:
       - when:
           condition:
             or:
+              - equal: [ '1.20', << parameters.version >> ]
               - equal: [ '1.19', << parameters.version >> ]
-              - equal: [ '1.18', << parameters.version >> ]
           steps:
             - run:
                 name: "Install tools"


### PR DESCRIPTION
# Description
The latest version of staticcheck no longer supports go1.18.
see: https://github.com/dominikh/go-tools/blob/master/go.mod

# Changes
go versions in ci config.

# Impact range
CI

# Operational Requirements

# Related Issue
<!--- Not obligatory, but write any issues if exists it -->

# Supplement
<!--- Not obligatory -->
