### PR TITLE
Use golang img instead of using cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         type: boolean
         default: true
     docker:
-      - image: "cimg/go:<< parameters.version >>"
+      - image: "golang:<< parameters.version >>"
     working_directory: ~/go/src/github.com/bmf-san/goblin
     environment:
       GO111MODULE: "on"


### PR DESCRIPTION
# Description
I want to be able to use the latest go version as much as possible.
There is no reason to dare to use cimg, so replace it.

# Changes
Use golang img in CI jobs.

# Impact range
Only CI.

# Operational Requirements

# Related Issue
<!--- Not obligatory, but write any issues if exists it -->

# Supplement
<!--- Not obligatory -->
