### PR TITLE
Update go version 1.22.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,31 +33,24 @@ jobs:
       - run:
           name: "Run go test"
           command: make test
-      - when:
-          condition:
-            or:
-              - equal: [ '1.21', << parameters.version >> ]
-              - equal: [ '1.20', << parameters.version >> ]
-              - equal: [ '1.19', << parameters.version >> ]
-          steps:
-            - run:
-                name: "Install tools"
-                command: make install-tools
-            - run:
-                name: "Run errcheck"
-                command: make errcheck
-            - run:
-                name: "Run go staticcheck"
-                command: make staticcheck
-            - run:
-                name: "Run gosec"
-                command: make gosec
-            - run:
-                name: "Run benchstat"
-                command: make benchstat
-            - run:
-                name: "Run govulncheck"
-                command: make govulncheck
+      - run:
+          name: "Install tools"
+          command: make install-tools
+      - run:
+          name: "Run errcheck"
+          command: make errcheck
+      - run:
+          name: "Run go staticcheck"
+          command: make staticcheck
+      - run:
+          name: "Run gosec"
+          command: make gosec
+      - run:
+          name: "Run benchstat"
+          command: make benchstat
+      - run:
+          name: "Run govulncheck"
+          command: make govulncheck
       - run:
           name: Build go
           command: go build
@@ -76,4 +69,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ["1.21", "1.20", "1.19", "1.18", "1.17", "1.16"]
+              version: ["1.22"]

--- a/Makefile
+++ b/Makefile
@@ -7,24 +7,12 @@ help:
 
 .PHONY: install-tools
 install-tools: ## Install staticcheck.
-ifeq ($(shell command -v staticcheck 2> /dev/null),)
 	go install honnef.co/go/tools/cmd/staticcheck@latest
-endif
-ifeq ($(shell command -v goimports 2> /dev/null),)
 	go install golang.org/x/tools/cmd/goimports@latest
-endif
-ifeq ($(shell command -v errcheck 2> /dev/null),)
 	go install github.com/kisielk/errcheck@latest
-endif
-ifeq ($(shell command -v gosec 2> /dev/null),)
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
-endif
-ifeq ($(shell command -v benchstat 2> /dev/null),)
 	go install golang.org/x/perf/cmd/benchstat@latest
-endif
-ifeq ($(shell govulncheck ./... 2> /dev/null),)
 	go install golang.org/x/vuln/cmd/govulncheck@latest
-endif
 
 .PHONY: gofmt
 gofmt: ## Run gofmt.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bmf-san/goblin
 
-go 1.21
+go 1.22.3


### PR DESCRIPTION
# Description
Support go1.22.3, and ending support for 1.21 and below.

# Changes
- Updated go version to 1.22.3
- Fixed install-tools command

# Impact range
Supported go versions.

# Operational Requirements
>= go1.22

# Related Issue
N/A

# Supplement
N/A
