### PR TITLE
set testcase names and use t.Run(name, func(){...})

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -21,30 +21,37 @@ func TestGetParam(t *testing.T) {
 	ngCtx := context.WithValue(context.Background(), ParamsKey, "not a []Param")
 
 	cases := []struct {
+		name     string
 		actual   string
 		expected string
 	}{
 		{
+			name:     "id_param",
 			actual:   GetParam(ctx, "id"),
 			expected: "123",
 		},
 		{
+			name:     "name_param",
 			actual:   GetParam(ctx, "name"),
 			expected: "john",
 		},
 		{
+			name:     "not_exist_param",
 			actual:   GetParam(ctx, "not-exist-key"),
 			expected: "",
 		},
 		{
+			name:     "param_value_wrong_type",
 			actual:   GetParam(ngCtx, "ng ctx"),
 			expected: "",
 		},
 	}
 
 	for _, c := range cases {
-		if c.actual != c.expected {
-			t.Errorf("actual:%v expected:%v", c.actual, c.expected)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if c.actual != c.expected {
+				t.Errorf("actual:%v expected:%v", c.actual, c.expected)
+			}
+		})
 	}
 }

--- a/router_test.go
+++ b/router_test.go
@@ -20,6 +20,17 @@ func TestNewRouter(t *testing.T) {
 	}
 }
 
+type routerTest struct {
+	path   string
+	method string
+	code   int
+	body   string
+}
+
+func (tc routerTest) name() string {
+	return fmt.Sprintf("%s_%s_%d", tc.method, tc.path, tc.code)
+}
+
 func TestRouterMiddleware(t *testing.T) {
 	r := NewRouter()
 
@@ -34,12 +45,7 @@ func TestRouterMiddleware(t *testing.T) {
 		fmt.Fprintf(w, "/middlewares\n")
 	}))
 
-	cases := []struct {
-		path   string
-		method string
-		code   int
-		body   string
-	}{
+	cases := []routerTest{
 		{
 			path:   "/globalmiddleware",
 			method: http.MethodGet,
@@ -61,22 +67,25 @@ func TestRouterMiddleware(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		req := httptest.NewRequest(c.method, c.path, nil)
-		rec := httptest.NewRecorder()
+		t.Run(c.name(), func(t *testing.T) {
+			req := httptest.NewRequest(c.method, c.path, nil)
+			rec := httptest.NewRecorder()
 
-		r.ServeHTTP(rec, req)
+			r.ServeHTTP(rec, req)
 
-		if rec.Code != c.code {
-			t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
-		}
+			if rec.Code != c.code {
+				t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
+			}
 
-		recBody, _ := io.ReadAll(rec.Body)
-		body := string(recBody)
-		if body != c.body {
-			t.Errorf("actual: %v expected: %v\n", body, c.body)
-		}
+			recBody, _ := io.ReadAll(rec.Body)
+			body := string(recBody)
+			if body != c.body {
+				t.Errorf("actual: %v expected: %v\n", body, c.body)
+			}
+		})
 	}
 }
+
 func TestRouter(t *testing.T) {
 	r := NewRouter()
 
@@ -142,12 +151,7 @@ func TestRouter(t *testing.T) {
 		fmt.Fprintf(w, "/%v", id)
 	}))
 
-	cases := []struct {
-		path   string
-		method string
-		code   int
-		body   string
-	}{
+	cases := []routerTest{
 		{
 			path:   "/",
 			method: http.MethodGet,
@@ -247,20 +251,22 @@ func TestRouter(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		req := httptest.NewRequest(c.method, c.path, nil)
-		rec := httptest.NewRecorder()
+		t.Run(c.name(), func(t *testing.T) {
+			req := httptest.NewRequest(c.method, c.path, nil)
+			rec := httptest.NewRecorder()
 
-		r.ServeHTTP(rec, req)
+			r.ServeHTTP(rec, req)
 
-		if rec.Code != c.code {
-			t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
-		}
+			if rec.Code != c.code {
+				t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
+			}
 
-		recBody, _ := io.ReadAll(rec.Body)
-		body := string(recBody)
-		if body != c.body {
-			t.Errorf("actual: %v expected: %v\n", body, c.body)
-		}
+			recBody, _ := io.ReadAll(rec.Body)
+			body := string(recBody)
+			if body != c.body {
+				t.Errorf("actual: %v expected: %v\n", body, c.body)
+			}
+		})
 	}
 }
 
@@ -269,11 +275,7 @@ func TestDefaultErrorHandler(t *testing.T) {
 	r.Methods(http.MethodGet).Handler(`/defaulterrorhandler`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	r.Methods(http.MethodGet).Handler(`/methodnotallowed`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
-	cases := []struct {
-		path   string
-		method string
-		code   int
-	}{
+	cases := []routerTest{
 		{
 			path:   "/",
 			method: http.MethodGet,
@@ -287,14 +289,16 @@ func TestDefaultErrorHandler(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		req := httptest.NewRequest(c.method, c.path, nil)
-		rec := httptest.NewRecorder()
+		t.Run(c.name(), func(t *testing.T) {
+			req := httptest.NewRequest(c.method, c.path, nil)
+			rec := httptest.NewRecorder()
 
-		r.ServeHTTP(rec, req)
+			r.ServeHTTP(rec, req)
 
-		if rec.Code != c.code {
-			t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
-		}
+			if rec.Code != c.code {
+				t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
+			}
+		})
 	}
 }
 
@@ -311,12 +315,7 @@ func TestCustomErrorHandler(t *testing.T) {
 	r.Methods(http.MethodGet).Handler(`/custommethodnotfound`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	r.Methods(http.MethodGet).Handler(`/custommethodnotallowed`, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
-	cases := []struct {
-		path   string
-		method string
-		code   int
-		body   string
-	}{
+	cases := []routerTest{
 		{
 			path:   "/",
 			method: http.MethodGet,
@@ -332,20 +331,22 @@ func TestCustomErrorHandler(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		req := httptest.NewRequest(c.method, c.path, nil)
-		rec := httptest.NewRecorder()
+		t.Run(c.name(), func(t *testing.T) {
+			req := httptest.NewRequest(c.method, c.path, nil)
+			rec := httptest.NewRecorder()
 
-		r.ServeHTTP(rec, req)
+			r.ServeHTTP(rec, req)
 
-		if rec.Code != c.code {
-			t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
-		}
+			if rec.Code != c.code {
+				t.Errorf("actual: %v expected: %v\n", rec.Code, c.code)
+			}
 
-		recBody, _ := io.ReadAll(rec.Body)
-		body := string(recBody)
-		if body != c.body {
-			t.Errorf("actual: %v expected: %v\n", body, c.body)
-		}
+			recBody, _ := io.ReadAll(rec.Body)
+			body := string(recBody)
+			if body != c.body {
+				t.Errorf("actual: %v expected: %v\n", body, c.body)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/bmf-san/goblin/issues/109

# Description
Set individual testcase names and use `testing.Run` when testing to identify which testcase failed

# Changes
Add a `name` field or `name()` function to each testcase type to identify testcase failures. Additionally wrap the execution of each case in `t.Run(name, func(){...})`.

# Impact range
All tests that create a slice of cases and iterate through them when running `go test`

# Operational Requirements

# Related Issue
[Add test case name to test cases.](https://github.com/bmf-san/goblin/issues/109)

# Supplement
Router test failures look like:
```
$ go test ./...
--- FAIL: TestRouterMiddleware (0.00s)
    --- FAIL: TestRouterMiddleware/GET_/globalmiddlewaree_200 (0.00s)
        router_test.go:77: actual: 404 expected: 200
        router_test.go:83: actual: 404 page not found
             expected: global: before
            /globalmiddleware
            global: after
            
FAIL
FAIL	github.com/bmf-san/goblin	0.566s
FAIL

```
Context test failures look like:
```
$ go test ./...
--- FAIL: TestGetParam (0.00s)
    --- FAIL: TestGetParam/id_param (0.00s)
        context_test.go:53: actual:123 expected:1233
FAIL
FAIL	github.com/bmf-san/goblin	0.535s
FAIL

```

Trie test failures that use the `caseWithFailure` type look like:
```
$ go test ./...
--- FAIL: TestSearchOnlyRoot (0.00s)
    --- FAIL: TestSearchOnlyRoot/no_error_with_/foo/bar_path (0.00s)
        trie_test.go:1008: actualAction: <nil> actualParams: [] expected err: no matching route was found
FAIL
FAIL	github.com/bmf-san/goblin	0.551s
FAIL

```

Trie test failures that use the `searchFailureTest` type look like:
```
$ go test ./...
--- FAIL: TestSearchFailure (0.00s)
    --- FAIL: TestSearchFailure/matching_handler_and_middlewares_was_found_1 (0.00s)
        trie_test.go:177: actualAction: &{[0xede3fa0] 0xedef320} actualParams: [] expected err: <nil>
FAIL
FAIL	github.com/bmf-san/goblin	0.550s
FAIL

```